### PR TITLE
BZ975930 Add jbossas7 module dependencies in jboss-deployment-structure....

### DIFF
--- a/kie-drools-wb/kie-drools-wb-distribution-wars/pom.xml
+++ b/kie-drools-wb/kie-drools-wb-distribution-wars/pom.xml
@@ -36,10 +36,6 @@
           </descriptors>
           <archive>
             <addMavenDescriptor>false</addMavenDescriptor>
-            <!-- See http://stackoverflow.com/questions/8286588/using-netty-inside-jboss-7-as -->
-            <manifestEntries>
-              <Dependencies>org.jboss.netty</Dependencies>
-            </manifestEntries>
           </archive>
         </configuration>
       </plugin>

--- a/kie-wb/kie-wb-distribution-wars/pom.xml
+++ b/kie-wb/kie-wb-distribution-wars/pom.xml
@@ -36,10 +36,6 @@
           </descriptors>
           <archive>
             <addMavenDescriptor>false</addMavenDescriptor>
-            <!-- See http://stackoverflow.com/questions/8286588/using-netty-inside-jboss-7-as -->
-            <manifestEntries>
-              <Dependencies>org.jboss.netty</Dependencies>
-            </manifestEntries>
           </archive>
         </configuration>
       </plugin>


### PR DESCRIPTION
...xml instead of MAINFEST.MF

Remove the dependency definition in MANIFEST.MF after jboss-deployment-structure.xml is used.
