### PR TITLE
kie-config-cli: exclude transitive deps. that are not needed

### DIFF
--- a/kie-config-cli/pom.xml
+++ b/kie-config-cli/pom.xml
@@ -212,6 +212,10 @@
           <groupId>org.kie.workbench.services</groupId>
           <artifactId>kie-wb-common-refactoring-backend</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.uberfire</groupId>
+          <artifactId>uberfire-client-all</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
 
@@ -377,6 +381,7 @@
               <overWriteReleases>false</overWriteReleases>
               <overWriteSnapshots>false</overWriteSnapshots>
               <overWriteIfNewer>true</overWriteIfNewer>
+              <includeScope>runtime</includeScope>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
I believe the uberfire-client-all should not be needed for the tool as it contain client (browser) specific stuff.

There are probably other transitive dependencies that could be excluded, but since there are no tests for the tool, I did not had the courage to remove the possible candidates :)

Also, using the `<includeScope>runtime</includeScope>` will prevent test dependencies (like mockito-all) to sneak into the distribution.

The final zip distribution size is reduced from MiB 69MiB to 39MiB.

@mswiderski could you please review and merge this (or provide feedback) when you have few minutes?
