### PR TITLE
Exclude cxf-bundle-jaxrs from eap63 and wildfly8 wars

### DIFF
--- a/kie-wb/kie-wb-distribution-wars/src/main/assembly/assembly-kie-wb-jboss-eap-6_1.xml
+++ b/kie-wb/kie-wb-distribution-wars/src/main/assembly/assembly-kie-wb-jboss-eap-6_1.xml
@@ -228,6 +228,7 @@
           <exclude>WEB-INF/lib/apache-mime4j-*.jar</exclude>
           <exclude>WEB-INF/lib/commons-configuration-*.jar</exclude>
           <exclude>WEB-INF/lib/cxf-api-*.jar</exclude>
+          <exclude>WEB-INF/lib/cxf-bundle-jaxrs-*.jar</exclude>
           <exclude>WEB-INF/lib/cxf-rt-bindings-soap-*.jar</exclude>
           <exclude>WEB-INF/lib/cxf-rt-bindings-xml-*.jar</exclude>
           <exclude>WEB-INF/lib/cxf-rt-core-*.jar</exclude>

--- a/kie-wb/kie-wb-distribution-wars/src/main/assembly/assembly-kie-wb-jboss-wildfly-8.xml
+++ b/kie-wb/kie-wb-distribution-wars/src/main/assembly/assembly-kie-wb-jboss-wildfly-8.xml
@@ -232,6 +232,7 @@
           <exclude>WEB-INF/lib/apache-mime4j-*.jar</exclude>
           <exclude>WEB-INF/lib/commons-configuration-*.jar</exclude>
           <exclude>WEB-INF/lib/cxf-api-*.jar</exclude>
+          <exclude>WEB-INF/lib/cxf-bundle-jaxrs-*.jar</exclude>
           <exclude>WEB-INF/lib/cxf-rt-bindings-soap-*.jar</exclude>
           <exclude>WEB-INF/lib/cxf-rt-bindings-xml-*.jar</exclude>
           <exclude>WEB-INF/lib/cxf-rt-core-*.jar</exclude>


### PR DESCRIPTION
I think the cxf jars should _not_ be included in the WEB-INF/lib as the war already depends on CXF module from EAP/WildFly. I am however quite new to this and I am not 100 % sure this the correct solution, so creating PR for review instead of directly committing the changes.
