### PR TITLE
gwt-maven-plugin refactored to avoid duplication

### DIFF
--- a/kie-wb/kie-wb-webapp/pom.xml
+++ b/kie-wb/kie-wb-webapp/pom.xml
@@ -1028,22 +1028,167 @@
       </resource>
     </resources>
 
-    <plugins>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <!-- Default configuration used for FastCompiled build. Includes the common GWT source artifacts and plugin
+               config. Product X community specific artifacts (e.g. home page) are specified using
+               profiles "producized" and "notProductized".
 
+               Keep the configuration here (pluginManagement) instead of directly in <plugins>. -->
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>gwt-maven-plugin</artifactId>
+          <configuration>
+            <module>org.kie.workbench.FastCompiledKIEWebapp</module>
+            <draftCompile>false</draftCompile>
+            <deploy>${project.build.directory}/gwt-symbols-deploy</deploy>
+            <localWorkers>1</localWorkers>
+            <logLevel>INFO</logLevel>
+            <runTarget>kie-wb.html</runTarget>
+            <extraJvmArgs>-Xmx4096m -Xms1024m -XX:MaxPermSize=256m -XX:PermSize=128m\
+              -Dorg.kie.demo=true\
+              -Dorg.kie.clean.onstartup=true\
+              -Dorg.uberfire.nio.git.ssh.enabled=false\
+              -Djava.security.auth.login.config=./src/main/resources/login-cli.conf\
+              -Djetty.custom.sys.classes=bitronix;javax.transaction\
+            </extraJvmArgs>
+            <!-- drools-compiler has dependency on org.eclipse.jdt.core.compiler:ecj:jar:,
+                 see http://code.google.com/p/google-web-toolkit/issues/detail?id=4479 -->
+            <gwtSdkFirstInClasspath>true</gwtSdkFirstInClasspath>
+            <compileSourcesArtifacts>
+              <!-- jBPM Console NG -->
+              <compileSourcesArtifact>org.jbpm:jbpm-console-ng-human-tasks-api</compileSourcesArtifact>
+              <compileSourcesArtifact>org.jbpm:jbpm-console-ng-human-tasks-client</compileSourcesArtifact>
+              <compileSourcesArtifact>org.jbpm:jbpm-console-ng-process-runtime-api</compileSourcesArtifact>
+              <compileSourcesArtifact>org.jbpm:jbpm-console-ng-process-runtime-client</compileSourcesArtifact>
+              <compileSourcesArtifact>org.jbpm:jbpm-console-ng-business-domain-api</compileSourcesArtifact>
+              <compileSourcesArtifact>org.jbpm:jbpm-console-ng-business-domain-client</compileSourcesArtifact>
+              <compileSourcesArtifact>org.jbpm:jbpm-console-ng-generic-client</compileSourcesArtifact>
+              <compileSourcesArtifact>org.jbpm:jbpm-console-ng-human-tasks-forms-client</compileSourcesArtifact>
+              <compileSourcesArtifact>org.jbpm:jbpm-console-ng-human-tasks-forms-modeler-client</compileSourcesArtifact>
+              <compileSourcesArtifact>org.jbpm:jbpm-console-ng-workbench-integration-client</compileSourcesArtifact>
+
+              <compileSourcesArtifact>org.jbpm:jbpm-designer-api</compileSourcesArtifact>
+              <compileSourcesArtifact>org.jbpm:jbpm-designer-client</compileSourcesArtifact>
+
+              <!-- jBPM Dashbuilder -->
+              <compileSourcesArtifact>org.jbpm:jbpm-console-ng-dashboard-api</compileSourcesArtifact>
+              <compileSourcesArtifact>org.jbpm:jbpm-console-ng-dashboard-client</compileSourcesArtifact>
+
+              <!-- jBPM Form Modeler -->
+              <compileSourcesArtifact>org.jbpm:jbpm-form-modeler-api</compileSourcesArtifact>
+              <compileSourcesArtifact>org.jbpm:jbpm-form-modeler-renderer-api</compileSourcesArtifact>
+              <compileSourcesArtifact>org.jbpm:jbpm-form-modeler-renderer-client</compileSourcesArtifact>
+              <compileSourcesArtifact>org.jbpm:jbpm-form-modeler-editor-api</compileSourcesArtifact>>
+              <compileSourcesArtifact>org.jbpm:jbpm-form-modeler-editor-client</compileSourcesArtifact>
+
+              <!-- Guvnor -->
+              <compileSourcesArtifact>org.guvnor:guvnor-structure-api</compileSourcesArtifact>
+              <compileSourcesArtifact>org.guvnor:guvnor-structure-client</compileSourcesArtifact>
+              <compileSourcesArtifact>org.guvnor:guvnor-inbox-api</compileSourcesArtifact>
+              <compileSourcesArtifact>org.guvnor:guvnor-inbox-client</compileSourcesArtifact>
+              <compileSourcesArtifact>org.guvnor:guvnor-m2repo-editor-api</compileSourcesArtifact>
+              <compileSourcesArtifact>org.guvnor:guvnor-m2repo-editor-client</compileSourcesArtifact>
+              <compileSourcesArtifact>org.guvnor:guvnor-workingset-api</compileSourcesArtifact>
+              <compileSourcesArtifact>org.guvnor:guvnor-workingset-client</compileSourcesArtifact>
+              <compileSourcesArtifact>org.guvnor:guvnor-services-api</compileSourcesArtifact>
+              <compileSourcesArtifact>org.guvnor:guvnor-project-api</compileSourcesArtifact>
+              <compileSourcesArtifact>org.guvnor:guvnor-project-client</compileSourcesArtifact>
+              <compileSourcesArtifact>org.guvnor:guvnor-message-console-api</compileSourcesArtifact>
+              <compileSourcesArtifact>org.guvnor:guvnor-message-console-client</compileSourcesArtifact>
+              <compileSourcesArtifact>org.guvnor:guvnor-organizationalunit-manager</compileSourcesArtifact>
+              <compileSourcesArtifact>org.guvnor:guvnor-asset-mgmt-api</compileSourcesArtifact>
+              <compileSourcesArtifact>org.guvnor:guvnor-asset-mgmt-client</compileSourcesArtifact>
+
+              <!-- Common dependencies -->
+              <compileSourcesArtifact>org.kie.workbench.screens:kie-wb-common-project-editor-api</compileSourcesArtifact>
+              <compileSourcesArtifact>org.kie.workbench.screens:kie-wb-common-project-editor-client</compileSourcesArtifact>
+              <compileSourcesArtifact>org.kie.workbench.screens:kie-wb-common-project-imports-editor-api
+              </compileSourcesArtifact>
+              <compileSourcesArtifact>org.kie.workbench.screens:kie-wb-common-project-imports-editor-client
+              </compileSourcesArtifact>
+              <compileSourcesArtifact>org.kie.workbench.screens:kie-wb-common-search-screen-api</compileSourcesArtifact>
+              <compileSourcesArtifact>org.kie.workbench.screens:kie-wb-common-search-screen-client</compileSourcesArtifact>
+              <compileSourcesArtifact>org.kie.workbench.screens:kie-wb-common-project-explorer-api</compileSourcesArtifact>
+              <compileSourcesArtifact>org.kie.workbench.screens:kie-wb-common-project-explorer-client</compileSourcesArtifact>
+              <compileSourcesArtifact>org.kie.workbench.screens:kie-wb-common-java-editor-api</compileSourcesArtifact>
+              <compileSourcesArtifact>org.kie.workbench.screens:kie-wb-common-java-editor-client</compileSourcesArtifact>
+              <compileSourcesArtifact>org.kie.workbench.screens:kie-wb-common-data-modeller-api</compileSourcesArtifact>
+              <compileSourcesArtifact>org.kie.workbench.screens:kie-wb-common-data-modeller-client</compileSourcesArtifact>
+              <compileSourcesArtifact>org.kie.workbench.screens:kie-wb-common-server-ui-client</compileSourcesArtifact>
+              <compileSourcesArtifact>org.kie.workbench.screens:kie-wb-common-contributors-client</compileSourcesArtifact>
+              <compileSourcesArtifact>org.kie.workbench.screens:kie-wb-common-social-home-page-client</compileSourcesArtifact>
+
+              <compileSourcesArtifact>org.kie.workbench.widgets:kie-wb-common-ui</compileSourcesArtifact>
+              <compileSourcesArtifact>org.kie.workbench.widgets:kie-wb-decorated-grid-widget</compileSourcesArtifact>
+              <compileSourcesArtifact>org.kie.workbench.widgets:kie-wb-metadata-widget</compileSourcesArtifact>
+              <compileSourcesArtifact>org.kie.workbench.widgets:kie-wb-config-resource-widget</compileSourcesArtifact>
+              <compileSourcesArtifact>org.kie.workbench.services:kie-wb-common-services-api</compileSourcesArtifact>
+              <compileSourcesArtifact>org.kie.workbench.services:kie-wb-common-datamodel-api</compileSourcesArtifact>
+              <compileSourcesArtifact>org.kie.workbench.services:kie-wb-common-refactoring-api</compileSourcesArtifact>
+
+              <!-- Models for Drools WB -->
+              <compileSourcesArtifact>org.drools:drools-workbench-models-commons</compileSourcesArtifact>
+              <compileSourcesArtifact>org.drools:drools-workbench-models-guided-dtable</compileSourcesArtifact>
+              <compileSourcesArtifact>org.drools:drools-workbench-models-guided-scorecard</compileSourcesArtifact>
+              <compileSourcesArtifact>org.drools:drools-workbench-models-guided-template</compileSourcesArtifact>
+              <compileSourcesArtifact>org.drools:drools-workbench-models-test-scenarios</compileSourcesArtifact>
+
+              <!-- Drools WB -->
+              <compileSourcesArtifact>org.drools:drools-wb-categories-editor-client</compileSourcesArtifact>
+              <compileSourcesArtifact>org.drools:drools-wb-enum-editor-api</compileSourcesArtifact>
+              <compileSourcesArtifact>org.drools:drools-wb-enum-editor-client</compileSourcesArtifact>
+              <compileSourcesArtifact>org.drools:drools-wb-drl-text-editor-api</compileSourcesArtifact>
+              <compileSourcesArtifact>org.drools:drools-wb-drl-text-editor-client</compileSourcesArtifact>
+              <compileSourcesArtifact>org.drools:drools-wb-factmodel-editor-api</compileSourcesArtifact>
+              <compileSourcesArtifact>org.drools:drools-wb-guided-rule-editor-api</compileSourcesArtifact>
+              <compileSourcesArtifact>org.drools:drools-wb-guided-rule-editor-client</compileSourcesArtifact>
+              <compileSourcesArtifact>org.drools:drools-wb-guided-template-editor-api</compileSourcesArtifact>
+              <compileSourcesArtifact>org.drools:drools-wb-guided-template-editor-client</compileSourcesArtifact>
+              <compileSourcesArtifact>org.drools:drools-wb-guided-dtable-editor-api</compileSourcesArtifact>
+              <compileSourcesArtifact>org.drools:drools-wb-guided-dtable-editor-client</compileSourcesArtifact>
+              <compileSourcesArtifact>org.drools:drools-wb-guided-dtree-editor-api</compileSourcesArtifact>
+              <compileSourcesArtifact>org.drools:drools-wb-guided-dtree-editor-client</compileSourcesArtifact>
+              <compileSourcesArtifact>org.drools:drools-wb-guided-scorecard-editor-api</compileSourcesArtifact>
+              <compileSourcesArtifact>org.drools:drools-wb-guided-scorecard-editor-client</compileSourcesArtifact>
+              <compileSourcesArtifact>org.drools:drools-wb-dsl-text-editor-api</compileSourcesArtifact>
+              <compileSourcesArtifact>org.drools:drools-wb-dsl-text-editor-client</compileSourcesArtifact>
+              <compileSourcesArtifact>org.drools:drools-wb-globals-editor-api</compileSourcesArtifact>
+              <compileSourcesArtifact>org.drools:drools-wb-globals-editor-client</compileSourcesArtifact>
+              <compileSourcesArtifact>org.drools:drools-wb-dtable-xls-editor-api</compileSourcesArtifact>
+              <compileSourcesArtifact>org.drools:drools-wb-dtable-xls-editor-client</compileSourcesArtifact>
+              <compileSourcesArtifact>org.drools:drools-wb-scorecard-xls-editor-api</compileSourcesArtifact>
+              <compileSourcesArtifact>org.drools:drools-wb-scorecard-xls-editor-client</compileSourcesArtifact>
+              <compileSourcesArtifact>org.drools:drools-wb-workitems-editor-api</compileSourcesArtifact>
+              <compileSourcesArtifact>org.drools:drools-wb-workitems-editor-client</compileSourcesArtifact>
+              <compileSourcesArtifact>org.drools:drools-wb-test-scenario-editor-api</compileSourcesArtifact>
+              <compileSourcesArtifact>org.drools:drools-wb-test-scenario-editor-client</compileSourcesArtifact>
+
+              <!-- UberFire -->
+              <compileSourcesArtifact>org.uberfire:uberfire-commons</compileSourcesArtifact>
+              <compileSourcesArtifact>org.uberfire:uberfire-nio2-model</compileSourcesArtifact>
+              <compileSourcesArtifact>org.uberfire:uberfire-api</compileSourcesArtifact>
+              <compileSourcesArtifact>org.uberfire:uberfire-js</compileSourcesArtifact>
+              <compileSourcesArtifact>org.uberfire:uberfire-security-api</compileSourcesArtifact>
+              <compileSourcesArtifact>org.uberfire:uberfire-security-client</compileSourcesArtifact>
+              <compileSourcesArtifact>org.uberfire:uberfire-client-api</compileSourcesArtifact>
+              <compileSourcesArtifact>org.uberfire:uberfire-workbench-client</compileSourcesArtifact>
+              <compileSourcesArtifact>org.uberfire:uberfire-workbench-client-backend</compileSourcesArtifact>
+              <compileSourcesArtifact>org.uberfire:uberfire-backend-api</compileSourcesArtifact>
+
+              <compileSourcesArtifact>org.uberfire:uberfire-runtime-plugins-client</compileSourcesArtifact>
+              <compileSourcesArtifact>org.uberfire:uberfire-perspective-editor-client</compileSourcesArtifact>
+              <compileSourcesArtifact>org.uberfire:uberfire-apps-client</compileSourcesArtifact>
+            </compileSourcesArtifacts>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+
+    <plugins>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>gwt-maven-plugin</artifactId>
-        <configuration>
-          <deploy>${project.build.directory}/gwt-symbols-deploy</deploy>
-          <localWorkers>1</localWorkers>
-          <module>org.kie.workbench.FastCompiledKIEWebapp</module>
-          <logLevel>INFO</logLevel>
-          <runTarget>kie-wb.html</runTarget>
-          <extraJvmArgs>-Xmx4096m -XX:MaxPermSize=256m -Xms1024m -XX:PermSize=128m -Dorg.kie.demo=true -Dorg.kie.clean.onstartup=true -Dorg.uberfire.nio.git.ssh.enabled=false -Djava.security.auth.login.config=./src/main/resources/login-cli.conf</extraJvmArgs>
-          <!-- drools-compiler has dependency on org.eclipse.jdt.core.compiler:ecj:jar:3.5.1:compile,
-          see http://code.google.com/p/google-web-toolkit/issues/detail?id=4479 -->
-          <gwtSdkFirstInClasspath>true</gwtSdkFirstInClasspath>
-        </configuration>
         <executions>
           <execution>
             <id>gwt-clean</id>
@@ -1105,31 +1250,6 @@
 
   <profiles>
     <profile>
-      <id>fullProfile</id>
-      <activation>
-        <property>
-          <name>full</name>
-        </property>
-      </activation>
-      <build>
-        <plugins>
-          <plugin><!-- Keep in sync with soa profile -->
-            <groupId>org.codehaus.mojo</groupId>
-            <artifactId>gwt-maven-plugin</artifactId>
-            <configuration>
-              <!-- Build all GWT permutations and optimize them -->
-              <module>org.kie.workbench.KIEWebapp</module>
-              <draftCompile>false</draftCompile>
-              <localWorkers>4</localWorkers>
-              <extraJvmArgs>-Xmx4096m -XX:MaxPermSize=256m -Xms2048m -XX:PermSize=128m -Djetty.custom.sys.classes=bitronix;javax.transaction -Dorg.kie.demo=true -Dorg.kie.clean.onstartup=true</extraJvmArgs>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-
-    <!-- Community Home Page -->
-    <profile>
       <id>notProductizedProfile</id>
       <activation>
         <property>
@@ -1145,149 +1265,25 @@
       </dependencies>
 
       <build>
-        <plugins>
-          <plugin>
-            <groupId>org.codehaus.mojo</groupId>
-            <artifactId>gwt-maven-plugin</artifactId>
-            <configuration>
-              <compileSourcesArtifacts>
-
-                <!-- jbpm-wb -->
-                <compileSourcesArtifact>org.jbpm:jbpm-console-ng-human-tasks-api</compileSourcesArtifact>
-                <compileSourcesArtifact>org.jbpm:jbpm-console-ng-human-tasks-client</compileSourcesArtifact>
-                <compileSourcesArtifact>org.jbpm:jbpm-console-ng-process-runtime-api</compileSourcesArtifact>
-                <compileSourcesArtifact>org.jbpm:jbpm-console-ng-process-runtime-client</compileSourcesArtifact>
-                <compileSourcesArtifact>org.jbpm:jbpm-console-ng-business-domain-api</compileSourcesArtifact>
-                <compileSourcesArtifact>org.jbpm:jbpm-console-ng-business-domain-client</compileSourcesArtifact>
-                <compileSourcesArtifact>org.jbpm:jbpm-console-ng-generic-client</compileSourcesArtifact>
-                <compileSourcesArtifact>org.jbpm:jbpm-console-ng-human-tasks-forms-client</compileSourcesArtifact>
-                <compileSourcesArtifact>org.jbpm:jbpm-console-ng-human-tasks-forms-modeler-client</compileSourcesArtifact>
-                <compileSourcesArtifact>org.jbpm:jbpm-console-ng-workbench-integration-client</compileSourcesArtifact>
-                
-                <compileSourcesArtifact>org.jbpm:jbpm-designer-api</compileSourcesArtifact>
-                <compileSourcesArtifact>org.jbpm:jbpm-designer-client</compileSourcesArtifact>
-
-                <!-- jBPM Dashbuilder integration. -->
-                <compileSourcesArtifact>org.jbpm:jbpm-console-ng-dashboard-api</compileSourcesArtifact>
-                <compileSourcesArtifact>org.jbpm:jbpm-console-ng-dashboard-client</compileSourcesArtifact>
-
-                <!-- form-modeler -->
-                <compileSourcesArtifact>org.jbpm:jbpm-form-modeler-api</compileSourcesArtifact>
-                <compileSourcesArtifact>org.jbpm:jbpm-form-modeler-renderer-api</compileSourcesArtifact>
-                <compileSourcesArtifact>org.jbpm:jbpm-form-modeler-renderer-client</compileSourcesArtifact>
-                <compileSourcesArtifact>org.jbpm:jbpm-form-modeler-editor-api</compileSourcesArtifact>>
-                <compileSourcesArtifact>org.jbpm:jbpm-form-modeler-editor-client</compileSourcesArtifact>
-
-                <!-- Guvnor -->
-                <compileSourcesArtifact>org.guvnor:guvnor-structure-api</compileSourcesArtifact>
-                <compileSourcesArtifact>org.guvnor:guvnor-structure-client</compileSourcesArtifact>
-                <compileSourcesArtifact>org.guvnor:guvnor-inbox-api</compileSourcesArtifact>
-                <compileSourcesArtifact>org.guvnor:guvnor-inbox-client</compileSourcesArtifact>
-                <compileSourcesArtifact>org.guvnor:guvnor-m2repo-editor-api</compileSourcesArtifact>
-                <compileSourcesArtifact>org.guvnor:guvnor-m2repo-editor-client</compileSourcesArtifact>
-                <compileSourcesArtifact>org.guvnor:guvnor-workingset-api</compileSourcesArtifact>
-                <compileSourcesArtifact>org.guvnor:guvnor-workingset-client</compileSourcesArtifact>
-                <compileSourcesArtifact>org.guvnor:guvnor-services-api</compileSourcesArtifact>
-                <compileSourcesArtifact>org.guvnor:guvnor-project-api</compileSourcesArtifact>
-                <compileSourcesArtifact>org.guvnor:guvnor-project-client</compileSourcesArtifact>
-                <compileSourcesArtifact>org.guvnor:guvnor-message-console-api</compileSourcesArtifact>
-                <compileSourcesArtifact>org.guvnor:guvnor-message-console-client</compileSourcesArtifact>
-                <compileSourcesArtifact>org.guvnor:guvnor-organizationalunit-manager</compileSourcesArtifact>
-                <compileSourcesArtifact>org.guvnor:guvnor-asset-mgmt-api</compileSourcesArtifact>
-                <compileSourcesArtifact>org.guvnor:guvnor-asset-mgmt-client</compileSourcesArtifact>
-
-                <!-- Community Home Page -->
-                <compileSourcesArtifact>org.kie:kie-wb-home-page-community</compileSourcesArtifact>
-                <compileSourcesArtifact>org.kie.workbench.screens:kie-wb-common-home-api</compileSourcesArtifact>
-                <compileSourcesArtifact>org.kie.workbench.screens:kie-wb-common-home-client</compileSourcesArtifact>
-
-                <!-- Common dependencies -->
-                <compileSourcesArtifact>org.kie.workbench.screens:kie-wb-common-project-editor-api</compileSourcesArtifact>
-                <compileSourcesArtifact>org.kie.workbench.screens:kie-wb-common-project-editor-client</compileSourcesArtifact>
-                <compileSourcesArtifact>org.kie.workbench.screens:kie-wb-common-project-imports-editor-api</compileSourcesArtifact>
-                <compileSourcesArtifact>org.kie.workbench.screens:kie-wb-common-project-imports-editor-client</compileSourcesArtifact>
-                <compileSourcesArtifact>org.kie.workbench.screens:kie-wb-common-search-screen-api</compileSourcesArtifact>
-                <compileSourcesArtifact>org.kie.workbench.screens:kie-wb-common-search-screen-client</compileSourcesArtifact>
-                <compileSourcesArtifact>org.kie.workbench.screens:kie-wb-common-project-explorer-api</compileSourcesArtifact>
-                <compileSourcesArtifact>org.kie.workbench.screens:kie-wb-common-project-explorer-client</compileSourcesArtifact>
-                <compileSourcesArtifact>org.kie.workbench.screens:kie-wb-common-java-editor-api</compileSourcesArtifact>
-                <compileSourcesArtifact>org.kie.workbench.screens:kie-wb-common-java-editor-client</compileSourcesArtifact>
-                <compileSourcesArtifact>org.kie.workbench.screens:kie-wb-common-data-modeller-api</compileSourcesArtifact>
-                <compileSourcesArtifact>org.kie.workbench.screens:kie-wb-common-data-modeller-client</compileSourcesArtifact>
-                <compileSourcesArtifact>org.kie.workbench.screens:kie-wb-common-server-ui-client</compileSourcesArtifact>
-                <compileSourcesArtifact>org.kie.workbench.screens:kie-wb-common-contributors-client</compileSourcesArtifact>
-                <compileSourcesArtifact>org.kie.workbench.screens:kie-wb-common-social-home-page-client</compileSourcesArtifact>
-
-                <compileSourcesArtifact>org.kie.workbench.widgets:kie-wb-common-ui</compileSourcesArtifact>
-                <compileSourcesArtifact>org.kie.workbench.widgets:kie-wb-decorated-grid-widget</compileSourcesArtifact>
-                <compileSourcesArtifact>org.kie.workbench.widgets:kie-wb-metadata-widget</compileSourcesArtifact>
-                <compileSourcesArtifact>org.kie.workbench.widgets:kie-wb-config-resource-widget</compileSourcesArtifact>
-                <compileSourcesArtifact>org.kie.workbench.services:kie-wb-common-services-api</compileSourcesArtifact>
-                <compileSourcesArtifact>org.kie.workbench.services:kie-wb-common-datamodel-api</compileSourcesArtifact>
-                <compileSourcesArtifact>org.kie.workbench.services:kie-wb-common-refactoring-api</compileSourcesArtifact>
-
-                <!-- Models for drools-wb -->
-                <compileSourcesArtifact>org.drools:drools-workbench-models-commons</compileSourcesArtifact>
-                <compileSourcesArtifact>org.drools:drools-workbench-models-guided-dtable</compileSourcesArtifact>
-                <compileSourcesArtifact>org.drools:drools-workbench-models-guided-scorecard</compileSourcesArtifact>
-                <compileSourcesArtifact>org.drools:drools-workbench-models-guided-template</compileSourcesArtifact>
-                <compileSourcesArtifact>org.drools:drools-workbench-models-test-scenarios</compileSourcesArtifact>
-
-                <!-- drools-wb -->
-                <compileSourcesArtifact>org.drools:drools-wb-categories-editor-client</compileSourcesArtifact>
-                <compileSourcesArtifact>org.drools:drools-wb-enum-editor-api</compileSourcesArtifact>
-                <compileSourcesArtifact>org.drools:drools-wb-enum-editor-client</compileSourcesArtifact>
-                <compileSourcesArtifact>org.drools:drools-wb-drl-text-editor-api</compileSourcesArtifact>
-                <compileSourcesArtifact>org.drools:drools-wb-drl-text-editor-client</compileSourcesArtifact>
-                <compileSourcesArtifact>org.drools:drools-wb-factmodel-editor-api</compileSourcesArtifact>
-                <compileSourcesArtifact>org.drools:drools-wb-guided-rule-editor-api</compileSourcesArtifact>
-                <compileSourcesArtifact>org.drools:drools-wb-guided-rule-editor-client</compileSourcesArtifact>
-                <compileSourcesArtifact>org.drools:drools-wb-guided-template-editor-api</compileSourcesArtifact>
-                <compileSourcesArtifact>org.drools:drools-wb-guided-template-editor-client</compileSourcesArtifact>
-                <compileSourcesArtifact>org.drools:drools-wb-guided-dtable-editor-api</compileSourcesArtifact>
-                <compileSourcesArtifact>org.drools:drools-wb-guided-dtable-editor-client</compileSourcesArtifact>
-                <compileSourcesArtifact>org.drools:drools-wb-guided-dtree-editor-api</compileSourcesArtifact>
-                <compileSourcesArtifact>org.drools:drools-wb-guided-dtree-editor-client</compileSourcesArtifact>
-                <compileSourcesArtifact>org.drools:drools-wb-guided-scorecard-editor-api</compileSourcesArtifact>
-                <compileSourcesArtifact>org.drools:drools-wb-guided-scorecard-editor-client</compileSourcesArtifact>
-                <compileSourcesArtifact>org.drools:drools-wb-dsl-text-editor-api</compileSourcesArtifact>
-                <compileSourcesArtifact>org.drools:drools-wb-dsl-text-editor-client</compileSourcesArtifact>
-                <compileSourcesArtifact>org.drools:drools-wb-globals-editor-api</compileSourcesArtifact>
-                <compileSourcesArtifact>org.drools:drools-wb-globals-editor-client</compileSourcesArtifact>
-                <compileSourcesArtifact>org.drools:drools-wb-dtable-xls-editor-api</compileSourcesArtifact>
-                <compileSourcesArtifact>org.drools:drools-wb-dtable-xls-editor-client</compileSourcesArtifact>
-                <compileSourcesArtifact>org.drools:drools-wb-scorecard-xls-editor-api</compileSourcesArtifact>
-                <compileSourcesArtifact>org.drools:drools-wb-scorecard-xls-editor-client</compileSourcesArtifact>
-                <compileSourcesArtifact>org.drools:drools-wb-workitems-editor-api</compileSourcesArtifact>
-                <compileSourcesArtifact>org.drools:drools-wb-workitems-editor-client</compileSourcesArtifact>
-                <compileSourcesArtifact>org.drools:drools-wb-test-scenario-editor-api</compileSourcesArtifact>
-                <compileSourcesArtifact>org.drools:drools-wb-test-scenario-editor-client</compileSourcesArtifact>
-
-                <!-- UberFire dependencies -->
-                <compileSourcesArtifact>org.uberfire:uberfire-commons</compileSourcesArtifact>
-                <compileSourcesArtifact>org.uberfire:uberfire-nio2-model</compileSourcesArtifact>
-                <compileSourcesArtifact>org.uberfire:uberfire-api</compileSourcesArtifact>
-                <compileSourcesArtifact>org.uberfire:uberfire-js</compileSourcesArtifact>
-                <compileSourcesArtifact>org.uberfire:uberfire-security-api</compileSourcesArtifact>
-                <compileSourcesArtifact>org.uberfire:uberfire-security-client</compileSourcesArtifact>
-                <compileSourcesArtifact>org.uberfire:uberfire-client-api</compileSourcesArtifact>
-                <compileSourcesArtifact>org.uberfire:uberfire-workbench-client</compileSourcesArtifact>
-                <compileSourcesArtifact>org.uberfire:uberfire-workbench-client-backend</compileSourcesArtifact>
-                <compileSourcesArtifact>org.uberfire:uberfire-backend-api</compileSourcesArtifact>
-
-                <compileSourcesArtifact>org.uberfire:uberfire-runtime-plugins-client</compileSourcesArtifact>
-                <compileSourcesArtifact>org.uberfire:uberfire-perspective-editor-client</compileSourcesArtifact>
-                <compileSourcesArtifact>org.uberfire:uberfire-apps-client</compileSourcesArtifact>
-
-              </compileSourcesArtifacts>
-            </configuration>
-          </plugin>
-        </plugins>
+        <pluginManagement>
+          <plugins>
+            <plugin>
+              <groupId>org.codehaus.mojo</groupId>
+              <artifactId>gwt-maven-plugin</artifactId>
+              <configuration>
+                <compileSourcesArtifacts combine.children="append">
+                  <!-- Community Home Page -->
+                  <compileSourcesArtifact>org.kie:kie-wb-home-page-community</compileSourcesArtifact>
+                  <compileSourcesArtifact>org.kie.workbench.screens:kie-wb-common-home-api</compileSourcesArtifact>
+                  <compileSourcesArtifact>org.kie.workbench.screens:kie-wb-common-home-client</compileSourcesArtifact>
+                </compileSourcesArtifacts>
+              </configuration>
+            </plugin>
+          </plugins>
+        </pluginManagement>
       </build>
-
     </profile>
 
-    <!-- Product Home Page -->
     <profile>
       <id>productizedProfile</id>
       <activation>
@@ -1304,152 +1300,49 @@
       </dependencies>
 
       <build>
-        <plugins>
-          <plugin>
-            <groupId>org.codehaus.mojo</groupId>
-            <artifactId>gwt-maven-plugin</artifactId>
-            <configuration>
-              <!-- Build all GWT permutations and optimize them -->
-              <!--<module>org.kie.workbench.KIEWebapp</module>-->
-              <draftCompile>false</draftCompile>
-              <localWorkers>4</localWorkers>
-              <extraJvmArgs>-Xmx4096m -XX:MaxPermSize=256m -Xms2048m -XX:PermSize=128m -Djetty.custom.sys.classes=bitronix;javax.transaction -Dorg.kie.demo=true -Dorg.kie.clean.onstartup=true</extraJvmArgs>
-              <compileSourcesArtifacts>
-
-                <!-- jbpm-wb -->
-                <compileSourcesArtifact>org.jbpm:jbpm-console-ng-human-tasks-api</compileSourcesArtifact>
-                <compileSourcesArtifact>org.jbpm:jbpm-console-ng-human-tasks-client</compileSourcesArtifact>
-                <compileSourcesArtifact>org.jbpm:jbpm-console-ng-process-runtime-api</compileSourcesArtifact>
-                <compileSourcesArtifact>org.jbpm:jbpm-console-ng-process-runtime-client</compileSourcesArtifact>
-                <compileSourcesArtifact>org.jbpm:jbpm-console-ng-business-domain-api</compileSourcesArtifact>
-                <compileSourcesArtifact>org.jbpm:jbpm-console-ng-business-domain-client</compileSourcesArtifact>
-                <compileSourcesArtifact>org.jbpm:jbpm-console-ng-generic-client</compileSourcesArtifact>
-                <compileSourcesArtifact>org.jbpm:jbpm-console-ng-human-tasks-forms-client</compileSourcesArtifact>
-
-                <compileSourcesArtifact>org.jbpm:jbpm-designer-api</compileSourcesArtifact>
-                <compileSourcesArtifact>org.jbpm:jbpm-designer-client</compileSourcesArtifact>
-
-                <!-- jBPM Dashbuilder integration. -->
-                <compileSourcesArtifact>org.jbpm:jbpm-console-ng-dashboard-api</compileSourcesArtifact>
-                <compileSourcesArtifact>org.jbpm:jbpm-console-ng-dashboard-client</compileSourcesArtifact>
-
-                <!-- form-modeler -->
-                <compileSourcesArtifact>org.jbpm:jbpm-form-modeler-api</compileSourcesArtifact>
-                <compileSourcesArtifact>org.jbpm:jbpm-form-modeler-renderer-api</compileSourcesArtifact>
-                <compileSourcesArtifact>org.jbpm:jbpm-form-modeler-renderer-client</compileSourcesArtifact>
-                <compileSourcesArtifact>org.jbpm:jbpm-form-modeler-editor-api</compileSourcesArtifact>>
-                <compileSourcesArtifact>org.jbpm:jbpm-form-modeler-editor-client</compileSourcesArtifact>
-
-                <!-- Guvnor -->
-                <compileSourcesArtifact>org.guvnor:guvnor-structure-api</compileSourcesArtifact>
-                <compileSourcesArtifact>org.guvnor:guvnor-structure-client</compileSourcesArtifact>
-                <compileSourcesArtifact>org.guvnor:guvnor-inbox-api</compileSourcesArtifact>
-                <compileSourcesArtifact>org.guvnor:guvnor-inbox-client</compileSourcesArtifact>
-                <compileSourcesArtifact>org.guvnor:guvnor-m2repo-editor-api</compileSourcesArtifact>
-                <compileSourcesArtifact>org.guvnor:guvnor-m2repo-editor-client</compileSourcesArtifact>
-                <compileSourcesArtifact>org.guvnor:guvnor-workingset-api</compileSourcesArtifact>
-                <compileSourcesArtifact>org.guvnor:guvnor-workingset-client</compileSourcesArtifact>
-                <compileSourcesArtifact>org.guvnor:guvnor-services-api</compileSourcesArtifact>
-                <compileSourcesArtifact>org.guvnor:guvnor-project-api</compileSourcesArtifact>
-                <compileSourcesArtifact>org.guvnor:guvnor-project-client</compileSourcesArtifact>
-                <compileSourcesArtifact>org.guvnor:guvnor-message-console-api</compileSourcesArtifact>
-                <compileSourcesArtifact>org.guvnor:guvnor-message-console-client</compileSourcesArtifact>
-                <compileSourcesArtifact>org.guvnor:guvnor-organizationalunit-manager</compileSourcesArtifact>
-                <compileSourcesArtifact>org.guvnor:guvnor-asset-mgmt-api</compileSourcesArtifact>
-                <compileSourcesArtifact>org.guvnor:guvnor-asset-mgmt-client</compileSourcesArtifact>
-
-                <!-- Product Home Page -->
-                <compileSourcesArtifact>org.kie:kie-wb-home-page-product</compileSourcesArtifact>
-                <compileSourcesArtifact>org.kie:kie-wb-distribution-home-api</compileSourcesArtifact>
-                <compileSourcesArtifact>org.kie:kie-wb-distribution-home-client</compileSourcesArtifact>
-
-                <!-- Common dependencies -->
-                <compileSourcesArtifact>org.kie.workbench.screens:kie-wb-common-project-editor-api</compileSourcesArtifact>
-                <compileSourcesArtifact>org.kie.workbench.screens:kie-wb-common-project-editor-client</compileSourcesArtifact>
-                <compileSourcesArtifact>org.kie.workbench.screens:kie-wb-common-project-imports-editor-api</compileSourcesArtifact>
-                <compileSourcesArtifact>org.kie.workbench.screens:kie-wb-common-project-imports-editor-client</compileSourcesArtifact>
-                <compileSourcesArtifact>org.kie.workbench.screens:kie-wb-common-search-screen-api</compileSourcesArtifact>
-                <compileSourcesArtifact>org.kie.workbench.screens:kie-wb-common-search-screen-client</compileSourcesArtifact>
-                <compileSourcesArtifact>org.kie.workbench.screens:kie-wb-common-project-explorer-api</compileSourcesArtifact>
-                <compileSourcesArtifact>org.kie.workbench.screens:kie-wb-common-project-explorer-client</compileSourcesArtifact>
-                <compileSourcesArtifact>org.kie.workbench.screens:kie-wb-common-java-editor-api</compileSourcesArtifact>
-                <compileSourcesArtifact>org.kie.workbench.screens:kie-wb-common-java-editor-client</compileSourcesArtifact>
-                <compileSourcesArtifact>org.kie.workbench.screens:kie-wb-common-data-modeller-api</compileSourcesArtifact>
-                <compileSourcesArtifact>org.kie.workbench.screens:kie-wb-common-data-modeller-client</compileSourcesArtifact>
-                <compileSourcesArtifact>org.kie.workbench.screens:kie-wb-common-server-ui-client</compileSourcesArtifact>
-                <compileSourcesArtifact>org.kie.workbench.screens:kie-wb-common-contributors-client</compileSourcesArtifact>
-                <compileSourcesArtifact>org.kie.workbench.screens:kie-wb-common-social-home-page-client</compileSourcesArtifact>
-
-                <compileSourcesArtifact>org.kie.workbench.widgets:kie-wb-common-ui</compileSourcesArtifact>
-                <compileSourcesArtifact>org.kie.workbench.widgets:kie-wb-decorated-grid-widget</compileSourcesArtifact>
-                <compileSourcesArtifact>org.kie.workbench.widgets:kie-wb-metadata-widget</compileSourcesArtifact>
-                <compileSourcesArtifact>org.kie.workbench.widgets:kie-wb-config-resource-widget</compileSourcesArtifact>
-                <compileSourcesArtifact>org.kie.workbench.services:kie-wb-common-services-api</compileSourcesArtifact>
-                <compileSourcesArtifact>org.kie.workbench.services:kie-wb-common-datamodel-api</compileSourcesArtifact>
-                <compileSourcesArtifact>org.kie.workbench.services:kie-wb-common-refactoring-api</compileSourcesArtifact>
-
-                <!-- Models for drools-wb -->
-                <compileSourcesArtifact>org.drools:drools-workbench-models-commons</compileSourcesArtifact>
-                <compileSourcesArtifact>org.drools:drools-workbench-models-guided-dtable</compileSourcesArtifact>
-                <compileSourcesArtifact>org.drools:drools-workbench-models-guided-scorecard</compileSourcesArtifact>
-                <compileSourcesArtifact>org.drools:drools-workbench-models-guided-template</compileSourcesArtifact>
-                <compileSourcesArtifact>org.drools:drools-workbench-models-test-scenarios</compileSourcesArtifact>
-
-                <!-- drools-wb -->
-                <compileSourcesArtifact>org.drools:drools-wb-categories-editor-client</compileSourcesArtifact>
-                <compileSourcesArtifact>org.drools:drools-wb-enum-editor-api</compileSourcesArtifact>
-                <compileSourcesArtifact>org.drools:drools-wb-enum-editor-client</compileSourcesArtifact>
-                <compileSourcesArtifact>org.drools:drools-wb-drl-text-editor-api</compileSourcesArtifact>
-                <compileSourcesArtifact>org.drools:drools-wb-drl-text-editor-client</compileSourcesArtifact>
-                <compileSourcesArtifact>org.drools:drools-wb-factmodel-editor-api</compileSourcesArtifact>
-                <compileSourcesArtifact>org.drools:drools-wb-guided-rule-editor-api</compileSourcesArtifact>
-                <compileSourcesArtifact>org.drools:drools-wb-guided-rule-editor-client</compileSourcesArtifact>
-                <compileSourcesArtifact>org.drools:drools-wb-guided-template-editor-api</compileSourcesArtifact>
-                <compileSourcesArtifact>org.drools:drools-wb-guided-template-editor-client</compileSourcesArtifact>
-                <compileSourcesArtifact>org.drools:drools-wb-guided-dtable-editor-api</compileSourcesArtifact>
-                <compileSourcesArtifact>org.drools:drools-wb-guided-dtable-editor-client</compileSourcesArtifact>
-                <compileSourcesArtifact>org.drools:drools-wb-guided-dtree-editor-api</compileSourcesArtifact>
-                <compileSourcesArtifact>org.drools:drools-wb-guided-dtree-editor-client</compileSourcesArtifact>
-                <compileSourcesArtifact>org.drools:drools-wb-guided-scorecard-editor-api</compileSourcesArtifact>
-                <compileSourcesArtifact>org.drools:drools-wb-guided-scorecard-editor-client</compileSourcesArtifact>
-                <compileSourcesArtifact>org.drools:drools-wb-dsl-text-editor-api</compileSourcesArtifact>
-                <compileSourcesArtifact>org.drools:drools-wb-dsl-text-editor-client</compileSourcesArtifact>
-                <compileSourcesArtifact>org.drools:drools-wb-globals-editor-api</compileSourcesArtifact>
-                <compileSourcesArtifact>org.drools:drools-wb-globals-editor-client</compileSourcesArtifact>
-                <compileSourcesArtifact>org.drools:drools-wb-dtable-xls-editor-api</compileSourcesArtifact>
-                <compileSourcesArtifact>org.drools:drools-wb-dtable-xls-editor-client</compileSourcesArtifact>
-                <compileSourcesArtifact>org.drools:drools-wb-scorecard-xls-editor-api</compileSourcesArtifact>
-                <compileSourcesArtifact>org.drools:drools-wb-scorecard-xls-editor-client</compileSourcesArtifact>
-                <compileSourcesArtifact>org.drools:drools-wb-workitems-editor-api</compileSourcesArtifact>
-                <compileSourcesArtifact>org.drools:drools-wb-workitems-editor-client</compileSourcesArtifact>
-                <compileSourcesArtifact>org.drools:drools-wb-test-scenario-editor-api</compileSourcesArtifact>
-                <compileSourcesArtifact>org.drools:drools-wb-test-scenario-editor-client</compileSourcesArtifact>
-
-                <!-- UberFire dependencies -->
-                <compileSourcesArtifact>org.uberfire:uberfire-commons</compileSourcesArtifact>
-                <compileSourcesArtifact>org.uberfire:uberfire-nio2-model</compileSourcesArtifact>
-                <compileSourcesArtifact>org.uberfire:uberfire-api</compileSourcesArtifact>
-                <compileSourcesArtifact>org.uberfire:uberfire-js</compileSourcesArtifact>
-                <compileSourcesArtifact>org.uberfire:uberfire-security-api</compileSourcesArtifact>
-                <compileSourcesArtifact>org.uberfire:uberfire-security-client</compileSourcesArtifact>
-                <compileSourcesArtifact>org.uberfire:uberfire-client-api</compileSourcesArtifact>
-                <compileSourcesArtifact>org.uberfire:uberfire-workbench-client</compileSourcesArtifact>
-                <compileSourcesArtifact>org.uberfire:uberfire-workbench-client-backend</compileSourcesArtifact>
-                <compileSourcesArtifact>org.uberfire:uberfire-backend-api</compileSourcesArtifact>
-
-                <compileSourcesArtifact>org.uberfire:uberfire-runtime-plugins-client</compileSourcesArtifact>
-                <compileSourcesArtifact>org.uberfire:uberfire-perspective-editor-client</compileSourcesArtifact>
-                <compileSourcesArtifact>org.uberfire:uberfire-apps-client</compileSourcesArtifact>
-
-              </compileSourcesArtifacts>
-            </configuration>
-          </plugin>
-
-        </plugins>
-
+        <pluginManagement>
+          <plugins>
+            <plugin>
+              <groupId>org.codehaus.mojo</groupId>
+              <artifactId>gwt-maven-plugin</artifactId>
+              <configuration>
+                <compileSourcesArtifacts combine.children="append">
+                  <!-- Product Home Page -->
+                  <compileSourcesArtifact>org.kie:kie-wb-home-page-product</compileSourcesArtifact>
+                  <compileSourcesArtifact>org.kie:kie-wb-distribution-home-api</compileSourcesArtifact>
+                  <compileSourcesArtifact>org.kie:kie-wb-distribution-home-client</compileSourcesArtifact>
+                </compileSourcesArtifacts>
+              </configuration>
+            </plugin>
+          </plugins>
+        </pluginManagement>
       </build>
-
     </profile>
+
+    <!-- Full profile builds all GWT permutions -->
+    <profile>
+      <id>fullProfile</id>
+      <activation>
+        <property>
+          <name>full</name>
+        </property>
+      </activation>
+      <build>
+        <pluginManagement>
+          <plugins>
+            <plugin>
+              <groupId>org.codehaus.mojo</groupId>
+              <artifactId>gwt-maven-plugin</artifactId>
+              <configuration>
+                <module>org.kie.workbench.KIEWebapp</module>
+                <draftCompile>false</draftCompile>
+                <localWorkers>4</localWorkers>
+                </configuration>
+              </plugin>
+            </plugins>
+          </pluginManagement>
+        </build>
+      </profile>
 
   </profiles>
 


### PR DESCRIPTION
The main reason for the change is to have single common `<compileSourcesArtifact>` list that can be shared between both community and product builds. The specific Home Page artifacts are then added in profiles. This avoids the need to keep both lists in sync (the lists are already out of sync).

The changes are currently just for `kie-wb`. Once (and if) we agree on the final look, I will also do the same for `kie-drools-wb`.

@manstis please take and let me know what you think.
