### PR TITLE
[6.5.x] GUVNOR-2790: Error happens when Execution server profile is used on Weblogic

### DIFF
--- a/kie-wb/kie-wb-distribution-wars/src/main/assembly/weblogic12/WEB-INF/web-exec-server.xml
+++ b/kie-wb/kie-wb-distribution-wars/src/main/assembly/weblogic12/WEB-INF/web-exec-server.xml
@@ -61,12 +61,6 @@
     <url-pattern>/*</url-pattern>
   </servlet-mapping>
 
-  <resource-env-ref>
-    <description>Object factory for the CDI Bean Manager</description>
-    <resource-env-ref-name>BeanManager</resource-env-ref-name>
-    <resource-env-ref-type>javax.enterprise.inject.spi.BeanManager</resource-env-ref-type>
-  </resource-env-ref>
-
   <welcome-file-list>
     <welcome-file>rest-api.jsp</welcome-file>
   </welcome-file-list>

--- a/kie-wb/kie-wb-distribution-wars/src/main/assembly/weblogic12/WEB-INF/web-ui-server.xml
+++ b/kie-wb/kie-wb-distribution-wars/src/main/assembly/weblogic12/WEB-INF/web-ui-server.xml
@@ -202,12 +202,6 @@ profile in pom.xml to use that. -->
   </servlet-mapping>
 
   <resource-env-ref>
-    <description>Object factory for the CDI Bean Manager</description>
-    <resource-env-ref-name>BeanManager</resource-env-ref-name>
-    <resource-env-ref-type>javax.enterprise.inject.spi.BeanManager</resource-env-ref-type>
-  </resource-env-ref>
-
-  <resource-env-ref>
     <description>Object factory for the Errai Service</description>
     <resource-env-ref-name>ErraiService</resource-env-ref-name>
     <resource-env-ref-type>org.jboss.errai.bus.server.service.ErraiService</resource-env-ref-type>


### PR DESCRIPTION
Removing this reference from WebLogic web.xml:
``` 
<resource-env-ref>		
  <description>Object factory for the CDI Bean Manager</description>
  <resource-env-ref-name>BeanManager</resource-env-ref-name>
  <resource-env-ref-type>javax.enterprise.inject.spi.BeanManager</resource-env-ref-type>
</resource-env-ref>
```

> WLS12c is a fully featured JEE application server and bean manager exists there by default, so this mapping is not needed.

See: https://issues.jboss.org/browse/GUVNOR-2790