### PR TITLE
[7.0.x] Remove Dash Boards permission for Product Home Page

### DIFF
--- a/kie-wb-parent/kie-wb-home-page-product/src/main/java/org/kie/workbench/client/home/HomeProducer.java
+++ b/kie-wb-parent/kie-wb-home-page-product/src/main/java/org/kie/workbench/client/home/HomeProducer.java
@@ -70,7 +70,6 @@ public class HomeProducer {
         s2.setPerspectiveId( PerspectiveIds.DEPLOYMENTS );
         s3.setPerspectiveId( PerspectiveIds.PROCESS_DEFINITIONS );
         s4.setPerspectiveId( PerspectiveIds.TASKS );
-        s5.setPermission( WorkbenchFeatures.MANAGE_DASHBOARDS );
 
         model.addSection( s1 );
         model.addSection( s2 );


### PR DESCRIPTION
@mbiarnes This should fix compilation for the "product" Home Page.

@dgutierr This was the simplest solution.. please check whether permission is still required.

(cherry picked from commit 65856d4c6e91b2d2a8239b7bcd37548cf0b4bcab)