### PR TITLE
[GUVNOR-2997] jms-api required by the kie-server-client

### DIFF
--- a/kie-drools-wb-parent/kie-drools-wb-webapp/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
+++ b/kie-drools-wb-parent/kie-drools-wb-webapp/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
@@ -25,6 +25,9 @@
            removed in future. WildFly also generates warning(s) during the deployment if
            the WAR depends on private modules. -->
       <!-- Keep the alphabetical order! -->
+      <!-- JMS API required by kie-server-client as there is an runtime API dependency
+           (even though the JMS is not being used for the communication itself). -->
+      <module name="javax.jms.api"/>
 
       <!-- ******************************************************************************************** -->
       <!-- EXCEPTIONS - private/unsupported modules that can not be directly added into the WEB-INF/lib -->

--- a/kie-wb-parent/kie-wb-webapp/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
+++ b/kie-wb-parent/kie-wb-webapp/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
@@ -25,6 +25,9 @@
            removed in future. WildFly also generates warning(s) during the deployment if
            the WAR depends on private modules. -->
       <!-- Keep the alphabetical order! -->
+      <!-- JMS API required by kie-server-client as there is an runtime API dependency
+           (even though the JMS is not being used for the communication itself). -->
+      <module name="javax.jms.api"/>
 
       <!-- ******************************************************************************************** -->
       <!-- EXCEPTIONS - private/unsupported modules that can not be directly added into the WEB-INF/lib -->


### PR DESCRIPTION
Backport of #490. @mswiderski I believe we need this for 7.0.x as well, correct?