### PR TITLE
[7.0.x] Default translation (locale == null) should be returned when there is no translation to a key in the active locale and the errai.i18n.default_per_key is set to true.

### DIFF
--- a/kie-drools-wb-parent/kie-drools-wb-webapp/src/main/resources/org/kie/workbench/drools/KIEDroolsWebapp.gwt.xml
+++ b/kie-drools-wb-parent/kie-drools-wb-webapp/src/main/resources/org/kie/workbench/drools/KIEDroolsWebapp.gwt.xml
@@ -130,4 +130,6 @@
   <!-- There is no "ie11" permutation. IE11 uses the Firefox one (gecko1_8) -->
   <set-property name="user.agent" value="gecko1_8,safari"/>
 
+  <set-property name="errai.i18n.default_per_key" value="true"/>
+
 </module>

--- a/kie-wb-parent/kie-wb-webapp/src/main/resources/org/kie/workbench/KIEWebapp.gwt.xml
+++ b/kie-wb-parent/kie-wb-webapp/src/main/resources/org/kie/workbench/KIEWebapp.gwt.xml
@@ -152,4 +152,6 @@
   <!-- There is no "ie11" permutation. IE11 uses the Firefox one (gecko1_8) -->
   <set-property name="user.agent" value="gecko1_8,safari"/>
 
+  <set-property name="errai.i18n.default_per_key" value="true"/>
+
 </module>


### PR DESCRIPTION
Depends on: https://github.com/errai/errai/pull/248