### PR TITLE
Move Swarm packaging to Community profile

### DIFF
--- a/kie-drools-wb-parent/kie-drools-wb-webapp/pom.xml
+++ b/kie-drools-wb-parent/kie-drools-wb-webapp/pom.xml
@@ -1847,31 +1847,6 @@
           </archive>
         </configuration>
       </plugin>
-      <plugin>
-        <groupId>org.wildfly.swarm</groupId>
-        <artifactId>wildfly-swarm-plugin</artifactId>
-        <configuration>
-          <fractionDetectMode>never</fractionDetectMode>
-          <fractions>
-            <fraction>logging</fraction>
-            <fraction>undertow</fraction>
-            <fraction>cdi</fraction>
-            <fraction>ejb</fraction>
-            <fraction>jaxrs</fraction>
-            <fraction>ee</fraction>
-            <fraction>security</fraction>
-            <fraction>management</fraction>
-            <fraction>datasources</fraction>
-          </fractions>
-        </configuration>
-        <executions>
-          <execution>
-            <goals>
-              <goal>package</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
 
       <plugin>
         <artifactId>maven-clean-plugin</artifactId>
@@ -1962,6 +1937,34 @@
             </plugin>
           </plugins>
         </pluginManagement>
+
+        <plugins>
+          <plugin>
+            <groupId>org.wildfly.swarm</groupId>
+            <artifactId>wildfly-swarm-plugin</artifactId>
+            <configuration>
+              <fractionDetectMode>never</fractionDetectMode>
+              <fractions>
+                <fraction>logging</fraction>
+                <fraction>undertow</fraction>
+                <fraction>cdi</fraction>
+                <fraction>ejb</fraction>
+                <fraction>jaxrs</fraction>
+                <fraction>ee</fraction>
+                <fraction>security</fraction>
+                <fraction>management</fraction>
+                <fraction>datasources</fraction>
+              </fractions>
+            </configuration>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>package</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
       </build>
     </profile>
 

--- a/kie-wb-parent/kie-wb-webapp/pom.xml
+++ b/kie-wb-parent/kie-wb-webapp/pom.xml
@@ -2213,31 +2213,6 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.wildfly.swarm</groupId>
-        <artifactId>wildfly-swarm-plugin</artifactId>
-        <configuration>
-          <fractionDetectMode>never</fractionDetectMode>
-          <fractions>
-            <fraction>logging</fraction>
-            <fraction>undertow</fraction>
-            <fraction>cdi</fraction>
-            <fraction>ejb</fraction>
-            <fraction>jaxrs</fraction>
-            <fraction>ee</fraction>
-            <fraction>security</fraction>
-            <fraction>management</fraction>
-            <fraction>datasources</fraction>
-          </fractions>
-        </configuration>
-        <executions>
-          <execution>
-            <goals>
-              <goal>package</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
         <artifactId>maven-clean-plugin</artifactId>
         <configuration>
           <filesets>
@@ -2393,6 +2368,34 @@
             </plugin>
           </plugins>
         </pluginManagement>
+
+        <plugins>
+          <plugin>
+            <groupId>org.wildfly.swarm</groupId>
+            <artifactId>wildfly-swarm-plugin</artifactId>
+            <configuration>
+              <fractionDetectMode>never</fractionDetectMode>
+              <fractions>
+                <fraction>logging</fraction>
+                <fraction>undertow</fraction>
+                <fraction>cdi</fraction>
+                <fraction>ejb</fraction>
+                <fraction>jaxrs</fraction>
+                <fraction>ee</fraction>
+                <fraction>security</fraction>
+                <fraction>management</fraction>
+                <fraction>datasources</fraction>
+              </fractions>
+            </configuration>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>package</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
       </build>
     </profile>
 


### PR DESCRIPTION
@mbiarnes This moves Swarm's plugin execution to Community only profile.

@psiroky FYI.. there is an issue with Swarm's plugin and Maven classifiers on the WAR ("-redhat" for product)