### PR TITLE
[6.5.x]  Add jcl-over-slf4j directly into WEB-INF/lib

### DIFF
--- a/kie-drools-wb/kie-drools-wb-distribution-wars/src/main/assembly/component-kie-drools-wb-tomcat-7-common.xml
+++ b/kie-drools-wb/kie-drools-wb-distribution-wars/src/main/assembly/component-kie-drools-wb-tomcat-7-common.xml
@@ -20,7 +20,6 @@
         <include>org.hibernate.common:hibernate-commons-annotations</include>
         <include>com.sun.xml.bind:jaxb-xjc</include>
         <include>org.jboss.logging:jboss-logging</include>
-        <include>org.slf4j:jcl-over-slf4j</include>
         <include>org.slf4j:slf4j-ext</include>
         <include>org.codehaus.jackson:jackson-jaxrs</include>
         <include>org.codehaus.woodstox:woodstox-core-asl</include>

--- a/kie-drools-wb/kie-drools-wb-distribution-wars/src/main/assembly/component-kie-drools-wb-weblogic-12-common.xml
+++ b/kie-drools-wb/kie-drools-wb-distribution-wars/src/main/assembly/component-kie-drools-wb-weblogic-12-common.xml
@@ -25,7 +25,6 @@
         <include>org.hibernate.common:hibernate-commons-annotations</include>
         <include>com.sun.xml.bind:jaxb-xjc</include>
         <include>org.jboss.logging:jboss-logging</include>
-        <include>org.slf4j:jcl-over-slf4j</include>
         <include>org.slf4j:slf4j-api</include>
         <include>org.slf4j:slf4j-ext</include>
         <include>org.slf4j:slf4j-jdk14:jar</include>

--- a/kie-drools-wb/kie-drools-wb-distribution-wars/src/main/assembly/component-kie-drools-wb-websphere-as-8-common.xml
+++ b/kie-drools-wb/kie-drools-wb-distribution-wars/src/main/assembly/component-kie-drools-wb-websphere-as-8-common.xml
@@ -23,7 +23,6 @@
         <include>org.hibernate.common:hibernate-commons-annotations</include>
         <include>com.sun.xml.bind:jaxb-xjc</include>
         <include>org.jboss.logging:jboss-logging</include>
-        <include>org.slf4j:jcl-over-slf4j</include>
         <include>org.slf4j:slf4j-api</include>
         <include>org.slf4j:slf4j-ext</include>
         <include>org.slf4j:slf4j-jdk14:jar</include>

--- a/kie-drools-wb/kie-drools-wb-distribution-wars/src/main/assembly/eap6_4/WEB-INF/jboss-deployment-structure.xml
+++ b/kie-drools-wb/kie-drools-wb-distribution-wars/src/main/assembly/eap6_4/WEB-INF/jboss-deployment-structure.xml
@@ -49,7 +49,6 @@
       <module name="org.jboss.xnio"/>
       <module name="org.slf4j"/>
       <module name="org.slf4j.ext"/>
-      <module name="org.slf4j.jcl-over-slf4j"/>
 
       <!-- EAP security management client. -->
       <module name="org.jboss.as.controller-client"/>

--- a/kie-drools-wb/kie-drools-wb-distribution-wars/src/main/assembly/wildfly10-eap7/WEB-INF/jboss-deployment-structure.xml
+++ b/kie-drools-wb/kie-drools-wb-distribution-wars/src/main/assembly/wildfly10-eap7/WEB-INF/jboss-deployment-structure.xml
@@ -52,7 +52,6 @@
       <module name="org.jboss.xnio"/>
       <module name="org.slf4j"/>
       <module name="org.slf4j.ext"/>
-      <module name="org.slf4j.jcl-over-slf4j"/>
 
 
       <!-- ******************************************************************************************** -->

--- a/kie-drools-wb/kie-drools-wb-webapp/pom.xml
+++ b/kie-drools-wb/kie-drools-wb-webapp/pom.xml
@@ -249,7 +249,6 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>jcl-over-slf4j</artifactId>
-      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/kie-drools-wb/kie-drools-wb-webapp/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
+++ b/kie-drools-wb/kie-drools-wb-webapp/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
@@ -54,7 +54,6 @@
       <module name="org.jboss.xnio"/>
       <module name="org.slf4j"/>
       <module name="org.slf4j.ext"/>
-      <module name="org.slf4j.jcl-over-slf4j"/>
 
 
       <!-- ******************************************************************************************** -->

--- a/kie-wb/kie-wb-distribution-wars/src/main/assembly/component-kie-wb-tomcat-7-common.xml
+++ b/kie-wb/kie-wb-distribution-wars/src/main/assembly/component-kie-wb-tomcat-7-common.xml
@@ -21,7 +21,6 @@
           <include>org.hibernate.common:hibernate-commons-annotations</include>
           <include>com.sun.xml.bind:jaxb-xjc</include>
           <include>org.jboss.logging:jboss-logging</include>
-          <include>org.slf4j:jcl-over-slf4j</include>
           <include>org.slf4j:slf4j-ext</include>
           <include>org.codehaus.woodstox:woodstox-core-asl</include>
           <include>org.codehaus.woodstox:stax2-api</include>

--- a/kie-wb/kie-wb-distribution-wars/src/main/assembly/component-kie-wb-weblogic-12-common.xml
+++ b/kie-wb/kie-wb-distribution-wars/src/main/assembly/component-kie-wb-weblogic-12-common.xml
@@ -24,7 +24,6 @@
           <include>org.hibernate.common:hibernate-commons-annotations</include>
           <include>com.sun.xml.bind:jaxb-xjc</include>
           <include>org.jboss.logging:jboss-logging</include>
-          <include>org.slf4j:jcl-over-slf4j</include>
           <include>org.slf4j:slf4j-api</include>
           <include>org.slf4j:slf4j-ext</include>
           <include>org.slf4j:slf4j-jdk14:jar</include>

--- a/kie-wb/kie-wb-distribution-wars/src/main/assembly/component-kie-wb-websphere-as-8-common.xml
+++ b/kie-wb/kie-wb-distribution-wars/src/main/assembly/component-kie-wb-websphere-as-8-common.xml
@@ -24,7 +24,6 @@
          <include>org.hibernate.common:hibernate-commons-annotations</include>
          <include>com.sun.xml.bind:jaxb-xjc</include>
          <include>org.jboss.logging:jboss-logging</include>
-         <include>org.slf4j:jcl-over-slf4j</include>
          <include>org.slf4j:slf4j-api</include>
          <include>org.slf4j:slf4j-ext</include>
          <include>org.slf4j:slf4j-jdk14:jar</include>

--- a/kie-wb/kie-wb-distribution-wars/src/main/assembly/eap6_4/WEB-INF/jboss-deployment-structure.xml
+++ b/kie-wb/kie-wb-distribution-wars/src/main/assembly/eap6_4/WEB-INF/jboss-deployment-structure.xml
@@ -49,7 +49,6 @@
       <module name="org.jboss.xnio"/>
       <module name="org.slf4j"/>
       <module name="org.slf4j.ext"/>
-      <module name="org.slf4j.jcl-over-slf4j"/>
 
       <!-- ******************************************************************************************** -->
       <!-- EXCEPTIONS - private/unsupported modules that can not be directly added into the WEB-INF/lib -->

--- a/kie-wb/kie-wb-distribution-wars/src/main/assembly/wildfly10-eap7/WEB-INF/jboss-deployment-structure.xml
+++ b/kie-wb/kie-wb-distribution-wars/src/main/assembly/wildfly10-eap7/WEB-INF/jboss-deployment-structure.xml
@@ -52,7 +52,6 @@
       <module name="org.jboss.xnio"/>
       <module name="org.slf4j"/>
       <module name="org.slf4j.ext"/>
-      <module name="org.slf4j.jcl-over-slf4j"/>
 
       <!-- ******************************************************************************************** -->
       <!-- EXCEPTIONS - private/unsupported modules that can not be directly added into the WEB-INF/lib -->

--- a/kie-wb/kie-wb-webapp/pom.xml
+++ b/kie-wb/kie-wb-webapp/pom.xml
@@ -232,7 +232,6 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>jcl-over-slf4j</artifactId>
-      <scope>provided</scope>
     </dependency>
 
     <!-- jBPM -->

--- a/kie-wb/kie-wb-webapp/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
+++ b/kie-wb/kie-wb-webapp/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
@@ -54,7 +54,6 @@
       <module name="org.jboss.xnio"/>
       <module name="org.slf4j"/>
       <module name="org.slf4j.ext"/>
-      <module name="org.slf4j.jcl-over-slf4j"/>
 
       <!-- ******************************************************************************************** -->
       <!-- EXCEPTIONS - private/unsupported modules that can not be directly added into the WEB-INF/lib -->


### PR DESCRIPTION
The private EAP module jcl-over-slf4j was removed in EAP 7.0.6 which
broke the deployment.

@AntStephenson could you please review?