### PR TITLE
AF-546: Make cacheable resources public to avoid non-caching headers.

### DIFF
--- a/kie-drools-wb-parent/kie-drools-wb-distribution-wars/src/main/assembly/tomcat8/WEB-INF/web.xml
+++ b/kie-drools-wb-parent/kie-drools-wb-distribution-wars/src/main/assembly/tomcat8/WEB-INF/web.xml
@@ -678,6 +678,24 @@ See http://www.w3.org/TR/SVG/intro.html#MIMEType. -->
     </auth-constraint>
   </security-constraint>
 
+  <!-- public resources -->
+  <security-constraint>
+    <web-resource-collection>
+      <web-resource-name>public</web-resource-name>
+      <url-pattern>/org.kie.workbench.drools.KIEDroolsWebapp/*.cache.*</url-pattern>
+      <url-pattern>/org.kie.workbench.drools.KIEDroolsWebapp/*.nocache.js</url-pattern>
+      <url-pattern>/org.kie.workbench.drools.KIEDroolsWebapp/ace/*</url-pattern>
+      <url-pattern>/org.kie.workbench.drools.KIEDroolsWebapp/bootstrap-daterangepicker/*</url-pattern>
+      <url-pattern>/org.kie.workbench.drools.KIEDroolsWebapp/bootstrap-select/*</url-pattern>
+      <url-pattern>/org.kie.workbench.drools.KIEDroolsWebapp/css/*</url-pattern>
+      <url-pattern>/org.kie.workbench.drools.KIEDroolsWebapp/deferredjs/*</url-pattern>
+      <url-pattern>/org.kie.workbench.drools.KIEDroolsWebapp/fonts/*</url-pattern>
+      <url-pattern>/org.kie.workbench.drools.KIEDroolsWebapp/img/*</url-pattern>
+      <url-pattern>/org.kie.workbench.drools.KIEDroolsWebapp/images/*</url-pattern>
+      <url-pattern>/org.kie.workbench.drools.KIEDroolsWebapp/zeroclipboard/*</url-pattern>
+    </web-resource-collection>
+  </security-constraint>
+
   <login-config>
     <auth-method>FORM</auth-method>
     <form-login-config>

--- a/kie-drools-wb-parent/kie-drools-wb-webapp/src/main/webapp/WEB-INF/web.xml
+++ b/kie-drools-wb-parent/kie-drools-wb-webapp/src/main/webapp/WEB-INF/web.xml
@@ -632,9 +632,17 @@ See http://www.w3.org/TR/SVG/intro.html#MIMEType. -->
   <security-constraint>
     <web-resource-collection>
       <web-resource-name>public</web-resource-name>
+      <url-pattern>/org.kie.workbench.drools.KIEDroolsWebapp/*.cache.*</url-pattern>
+      <url-pattern>/org.kie.workbench.drools.KIEDroolsWebapp/*.nocache.js</url-pattern>
+      <url-pattern>/org.kie.workbench.drools.KIEDroolsWebapp/ace/*</url-pattern>
+      <url-pattern>/org.kie.workbench.drools.KIEDroolsWebapp/bootstrap-daterangepicker/*</url-pattern>
+      <url-pattern>/org.kie.workbench.drools.KIEDroolsWebapp/bootstrap-select/*</url-pattern>
       <url-pattern>/org.kie.workbench.drools.KIEDroolsWebapp/css/*</url-pattern>
+      <url-pattern>/org.kie.workbench.drools.KIEDroolsWebapp/deferredjs/*</url-pattern>
       <url-pattern>/org.kie.workbench.drools.KIEDroolsWebapp/fonts/*</url-pattern>
       <url-pattern>/org.kie.workbench.drools.KIEDroolsWebapp/img/*</url-pattern>
+      <url-pattern>/org.kie.workbench.drools.KIEDroolsWebapp/images/*</url-pattern>
+      <url-pattern>/org.kie.workbench.drools.KIEDroolsWebapp/zeroclipboard/*</url-pattern>
     </web-resource-collection>
   </security-constraint>
 

--- a/kie-wb-parent/kie-wb-distribution-wars/src/main/assembly/tomcat8/WEB-INF/web.xml
+++ b/kie-wb-parent/kie-wb-distribution-wars/src/main/assembly/tomcat8/WEB-INF/web.xml
@@ -714,6 +714,24 @@ See http://www.w3.org/TR/SVG/intro.html#MIMEType. -->
     </auth-constraint>
   </security-constraint>
 
+  <!-- public resources -->
+  <security-constraint>
+    <web-resource-collection>
+      <web-resource-name>public</web-resource-name>
+      <url-pattern>/org.kie.workbench.KIEWebapp/*.cache.*</url-pattern>
+      <url-pattern>/org.kie.workbench.KIEWebapp/*.nocache.js</url-pattern>
+      <url-pattern>/org.kie.workbench.KIEWebapp/ace/*</url-pattern>
+      <url-pattern>/org.kie.workbench.KIEWebapp/bootstrap-daterangepicker/*</url-pattern>
+      <url-pattern>/org.kie.workbench.KIEWebapp/bootstrap-select/*</url-pattern>
+      <url-pattern>/org.kie.workbench.KIEWebapp/css/*</url-pattern>
+      <url-pattern>/org.kie.workbench.KIEWebapp/deferredjs/*</url-pattern>
+      <url-pattern>/org.kie.workbench.KIEWebapp/fonts/*</url-pattern>
+      <url-pattern>/org.kie.workbench.KIEWebapp/img/*</url-pattern>
+      <url-pattern>/org.kie.workbench.KIEWebapp/images/*</url-pattern>
+      <url-pattern>/org.kie.workbench.KIEWebapp/zeroclipboard/*</url-pattern>
+    </web-resource-collection>
+  </security-constraint>
+
   <login-config>
     <auth-method>FORM</auth-method>
     <form-login-config>

--- a/kie-wb-parent/kie-wb-webapp/src/main/webapp/WEB-INF/web.xml
+++ b/kie-wb-parent/kie-wb-webapp/src/main/webapp/WEB-INF/web.xml
@@ -655,9 +655,17 @@ See http://www.w3.org/TR/SVG/intro.html#MIMEType. -->
   <security-constraint>
     <web-resource-collection>
       <web-resource-name>public</web-resource-name>
+      <url-pattern>/org.kie.workbench.KIEWebapp/*.cache.*</url-pattern>
+      <url-pattern>/org.kie.workbench.KIEWebapp/*.nocache.js</url-pattern>
+      <url-pattern>/org.kie.workbench.KIEWebapp/ace/*</url-pattern>
+      <url-pattern>/org.kie.workbench.KIEWebapp/bootstrap-daterangepicker/*</url-pattern>
+      <url-pattern>/org.kie.workbench.KIEWebapp/bootstrap-select/*</url-pattern>
       <url-pattern>/org.kie.workbench.KIEWebapp/css/*</url-pattern>
+      <url-pattern>/org.kie.workbench.KIEWebapp/deferredjs/*</url-pattern>
       <url-pattern>/org.kie.workbench.KIEWebapp/fonts/*</url-pattern>
       <url-pattern>/org.kie.workbench.KIEWebapp/img/*</url-pattern>
+      <url-pattern>/org.kie.workbench.KIEWebapp/images/*</url-pattern>
+      <url-pattern>/org.kie.workbench.KIEWebapp/zeroclipboard/*</url-pattern>
     </web-resource-collection>
   </security-constraint>
 


### PR DESCRIPTION
WildFly adds the "no-cache" header to secured resources, preventing them from being cached. I have added *.cache.js files and many other static resources as public so that they can be cached.

I applied the same changes to the other application server configs for consistency. I do not know whether they suffered from the same issue.

Not sure who is best to review this. @psiroky @manstis?