### PR TITLE
AF-593: Decouple kie-wb-common-datamodel from Drools

### DIFF
--- a/kie-drools-wb-parent/kie-drools-wb-webapp/pom.xml
+++ b/kie-drools-wb-parent/kie-drools-wb-webapp/pom.xml
@@ -1049,6 +1049,10 @@
       <artifactId>uberfire-commons</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.kie.soup</groupId>
+      <artifactId>kie-soup-commons</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-metadata-api</artifactId>
     </dependency>
@@ -1332,6 +1336,10 @@
       <groupId>org.jboss.errai</groupId>
       <artifactId>errai-jaxrs-client</artifactId>
       <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.drools</groupId>
+      <artifactId>drools-cdi</artifactId>
     </dependency>
 
     <!-- GWT and GWT Extensions -->
@@ -1961,6 +1969,8 @@
               <compileSourcesArtifact>org.optaplanner:optaplanner-wb-guided-rule-editor-client</compileSourcesArtifact>
               <compileSourcesArtifact>org.optaplanner:optaplanner-wb-solver-editor-api</compileSourcesArtifact>
               <compileSourcesArtifact>org.optaplanner:optaplanner-wb-solver-editor-client</compileSourcesArtifact>
+
+              <compileSourcesArtifact>org.kie.soup:kie-soup-commons</compileSourcesArtifact>
 
               <!-- UberFire -->
               <compileSourcesArtifact>org.uberfire:uberfire-maven-support</compileSourcesArtifact>

--- a/kie-wb-parent/kie-wb-monitoring-webapp/pom.xml
+++ b/kie-wb-parent/kie-wb-monitoring-webapp/pom.xml
@@ -618,6 +618,10 @@
       <artifactId>uberfire-commons</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.kie.soup</groupId>
+      <artifactId>kie-soup-commons</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-io</artifactId>
     </dependency>
@@ -1374,6 +1378,8 @@
             <!-- Datasource management -->
             <compileSourcesArtifact>org.kie.workbench.screens:kie-wb-common-datasource-mgmt-api</compileSourcesArtifact>
             <compileSourcesArtifact>org.kie.workbench.screens:kie-wb-common-datasource-mgmt-client</compileSourcesArtifact>
+
+            <compileSourcesArtifact>org.kie.soup:kie-soup-commons</compileSourcesArtifact>
 
             <!-- UberFire -->
             <compileSourcesArtifact>org.uberfire:uberfire-maven-support</compileSourcesArtifact>

--- a/kie-wb-parent/kie-wb-webapp/pom.xml
+++ b/kie-wb-parent/kie-wb-webapp/pom.xml
@@ -939,6 +939,10 @@
       <artifactId>errai-jaxrs-client</artifactId>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>org.drools</groupId>
+      <artifactId>drools-cdi</artifactId>
+    </dependency>
 
     <!-- GWT and GWT Extensions -->
     <dependency>
@@ -1130,6 +1134,10 @@
     <dependency>
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-commons</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.kie.soup</groupId>
+      <artifactId>kie-soup-commons</artifactId>
     </dependency>
     <dependency>
       <groupId>org.uberfire</groupId>
@@ -2317,6 +2325,8 @@
             <compileSourcesArtifact>org.optaplanner:optaplanner-wb-guided-rule-editor-client</compileSourcesArtifact>
             <compileSourcesArtifact>org.optaplanner:optaplanner-wb-solver-editor-api</compileSourcesArtifact>
             <compileSourcesArtifact>org.optaplanner:optaplanner-wb-solver-editor-client</compileSourcesArtifact>
+
+            <compileSourcesArtifact>org.kie.soup:kie-soup-commons</compileSourcesArtifact>
 
             <!-- UberFire -->
             <compileSourcesArtifact>org.uberfire:uberfire-maven-support</compileSourcesArtifact>


### PR DESCRIPTION
Related:
https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/541
https://github.com/kiegroup/droolsjbpm-knowledge/pull/263
https://github.com/kiegroup/drools/pull/1444
https://github.com/kiegroup/jbpm/pull/973
https://github.com/kiegroup/droolsjbpm-integration/pull/1163
https://github.com/kiegroup/kie-wb-common/pull/1133
https://github.com/kiegroup/drools-wb/pull/596
https://github.com/kiegroup/jbpm-designer/pull/654
https://github.com/kiegroup/jbpm-wb/pull/864
https://github.com/kiegroup/optaplanner-wb/pull/218
https://github.com/kiegroup/droolsjbpm-tools/pull/82