### PR TITLE
JBPM-6432: Mega menu navigation configuration settings

### DIFF
--- a/kie-drools-wb-parent/kie-drools-wb-webapp/src/main/java/org/kie/workbench/drools/client/KieDroolsWorkbenchEntryPoint.java
+++ b/kie-drools-wb-parent/kie-drools-wb-webapp/src/main/java/org/kie/workbench/drools/client/KieDroolsWorkbenchEntryPoint.java
@@ -154,12 +154,18 @@ public class KieDroolsWorkbenchEntryPoint extends DefaultWorkbenchEntryPoint {
 
         // Due to a limitation in the Menus API the number of levels in the workbench's menu bar
         // navigation tree node must be limited to 2 (see https://issues.jboss.org/browse/GUVNOR-2992)
-        navTreeEditor.setMaxLevels(NavTreeDefinitions.GROUP_WORKBENCH,
-                                   2);
+        navTreeEditor.setMaxLevels(NavTreeDefinitions.GROUP_WORKBENCH, 2);
 
-        // Mega Menu does not support dividers and root menu items (menu items are only allowed inside menu groups).
-        navTreeEditor.setNewDividerEnabled(false);
-        navTreeEditor.setNewPerspectiveEnabled(NavTreeDefinitions.GROUP_WORKBENCH,
-                                               false);
+        // Mega Menu does not support dividers at any level
+        navTreeEditor.setNewDividerEnabled(NavTreeDefinitions.GROUP_WORKBENCH, false).applyToAllChildren();
+
+        // Mega Menu does not support single menu items at first level (menu items are only allowed inside menu groups).
+        navTreeEditor.setNewPerspectiveEnabled(NavTreeDefinitions.GROUP_WORKBENCH, false);
+
+        // Mega Menu is the only nav widget which allow links to core perspectives
+        navTreeEditor.setOnlyRuntimePerspectives(NavTreeDefinitions.GROUP_WORKBENCH, false).applyToAllChildren();
+
+        // Mega Menu's linked perspectives don't support passing a navigation context
+        navTreeEditor.setPerspectiveContextEnabled(NavTreeDefinitions.GROUP_WORKBENCH, false).applyToAllChildren();
     }
 }

--- a/kie-drools-wb-parent/kie-drools-wb-webapp/src/test/java/org/kie/workbench/drools/client/KieDroolsWorkbenchEntryPointTest.java
+++ b/kie-drools-wb-parent/kie-drools-wb-webapp/src/test/java/org/kie/workbench/drools/client/KieDroolsWorkbenchEntryPointTest.java
@@ -26,6 +26,7 @@ import org.dashbuilder.navigation.NavItem;
 import org.dashbuilder.navigation.NavTree;
 import org.dashbuilder.navigation.service.NavigationServices;
 import org.guvnor.common.services.shared.config.AppConfigService;
+import org.jboss.errai.ioc.client.container.SyncBeanManager;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -35,6 +36,7 @@ import org.kie.workbench.common.workbench.client.menu.DefaultWorkbenchFeaturesMe
 import org.kie.workbench.drools.client.navigation.NavTreeDefinitions;
 import org.kie.workbench.drools.client.resources.i18n.NavigationConstants;
 import org.mockito.Mock;
+import org.uberfire.client.authz.PerspectiveTreeProvider;
 import org.uberfire.client.mvp.ActivityBeansCache;
 import org.uberfire.client.workbench.Workbench;
 import org.uberfire.client.workbench.widgets.menu.megamenu.WorkbenchMegaMenuPresenter;
@@ -69,6 +71,12 @@ public class KieDroolsWorkbenchEntryPointTest {
 
     @Mock
     protected PermissionTreeSetup permissionTreeSetup;
+
+    @Mock
+    private PerspectiveTreeProvider perspectiveTreeProvider;
+
+    @Mock
+    private SyncBeanManager syncBeanManager;
 
     @Mock
     private DefaultAdminPageHelper adminPageHelper;
@@ -121,6 +129,8 @@ public class KieDroolsWorkbenchEntryPointTest {
                                                                       contentExplorerScreen));
 
         doNothing().when(kieWorkbenchEntryPoint).hideLoadingPopup();
+
+        navTreeEditor = spy(new NavTreeEditor(mock(NavTreeEditor.View.class), syncBeanManager, perspectiveTreeProvider));
         when(contentExplorerScreen.getNavTreeEditor()).thenReturn(navTreeEditor);
     }
 
@@ -130,12 +140,11 @@ public class KieDroolsWorkbenchEntryPointTest {
 
         verify(workbench).addStartupBlocker(KieDroolsWorkbenchEntryPoint.class);
         verify(permissionTreeSetup).configureTree();
-        verify(navTreeEditor).setMaxLevels(NavTreeDefinitions.GROUP_WORKBENCH,
-                                           2);
-        verify(navTreeEditor).setNewDividerEnabled(false);
-        verify(navTreeEditor).setNewPerspectiveEnabled(NavTreeDefinitions.GROUP_WORKBENCH,
-                                                       false);
-    }
+        verify(navTreeEditor).setMaxLevels(NavTreeDefinitions.GROUP_WORKBENCH, 2);
+        verify(navTreeEditor).setNewDividerEnabled(NavTreeDefinitions.GROUP_WORKBENCH, false);
+        verify(navTreeEditor).setNewPerspectiveEnabled(NavTreeDefinitions.GROUP_WORKBENCH, false);
+        verify(navTreeEditor).setOnlyRuntimePerspectives(NavTreeDefinitions.GROUP_WORKBENCH, false);
+        verify(navTreeEditor).setPerspectiveContextEnabled(NavTreeDefinitions.GROUP_WORKBENCH, false);    }
 
     @Test
     public void setupMenuTest() {

--- a/kie-wb-parent/kie-wb-webapp/src/main/java/org/kie/workbench/client/KieWorkbenchEntryPoint.java
+++ b/kie-wb-parent/kie-wb-webapp/src/main/java/org/kie/workbench/client/KieWorkbenchEntryPoint.java
@@ -156,12 +156,18 @@ public class KieWorkbenchEntryPoint extends DefaultWorkbenchEntryPoint {
 
         // Due to a limitation in the Menus API the number of levels in the workbench's menu bar
         // navigation tree node must be limited to 2 (see https://issues.jboss.org/browse/GUVNOR-2992)
-        navTreeEditor.setMaxLevels(NavTreeDefinitions.GROUP_WORKBENCH,
-                                   2);
+        navTreeEditor.setMaxLevels(NavTreeDefinitions.GROUP_WORKBENCH, 2);
 
-        // Mega Menu does not support dividers and root menu items (menu items are only allowed inside menu groups).
-        navTreeEditor.setNewDividerEnabled(false);
-        navTreeEditor.setNewPerspectiveEnabled(NavTreeDefinitions.GROUP_WORKBENCH,
-                                               false);
+        // Mega Menu does not support dividers at any level
+        navTreeEditor.setNewDividerEnabled(NavTreeDefinitions.GROUP_WORKBENCH, false).applyToAllChildren();
+
+        // Mega Menu does not support single menu items at first level (menu items are only allowed inside menu groups).
+        navTreeEditor.setNewPerspectiveEnabled(NavTreeDefinitions.GROUP_WORKBENCH, false);
+
+        // Mega Menu is the only nav widget which allow links to core perspectives
+        navTreeEditor.setOnlyRuntimePerspectives(NavTreeDefinitions.GROUP_WORKBENCH, false).applyToAllChildren();
+
+        // Mega Menu's linked perspectives don't support passing a navigation context
+        navTreeEditor.setPerspectiveContextEnabled(NavTreeDefinitions.GROUP_WORKBENCH, false).applyToAllChildren();
     }
 }

--- a/kie-wb-parent/kie-wb-webapp/src/test/java/org/kie/workbench/client/KieWorkbenchEntryPointTest.java
+++ b/kie-wb-parent/kie-wb-webapp/src/test/java/org/kie/workbench/client/KieWorkbenchEntryPointTest.java
@@ -26,6 +26,7 @@ import org.dashbuilder.navigation.NavItem;
 import org.dashbuilder.navigation.NavTree;
 import org.dashbuilder.navigation.service.NavigationServices;
 import org.guvnor.common.services.shared.config.AppConfigService;
+import org.jboss.errai.ioc.client.container.SyncBeanManager;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -35,6 +36,7 @@ import org.kie.workbench.common.workbench.client.admin.DefaultAdminPageHelper;
 import org.kie.workbench.common.workbench.client.authz.PermissionTreeSetup;
 import org.kie.workbench.common.workbench.client.menu.DefaultWorkbenchFeaturesMenusHelper;
 import org.mockito.Mock;
+import org.uberfire.client.authz.PerspectiveTreeProvider;
 import org.uberfire.client.mvp.ActivityBeansCache;
 import org.uberfire.client.workbench.Workbench;
 import org.uberfire.client.workbench.widgets.menu.megamenu.WorkbenchMegaMenuPresenter;
@@ -69,6 +71,12 @@ public class KieWorkbenchEntryPointTest {
 
     @Mock
     protected PermissionTreeSetup permissionTreeSetup;
+
+    @Mock
+    private PerspectiveTreeProvider perspectiveTreeProvider;
+
+    @Mock
+    private SyncBeanManager syncBeanManager;
 
     @Mock
     private DefaultAdminPageHelper adminPageHelper;
@@ -121,6 +129,8 @@ public class KieWorkbenchEntryPointTest {
                                                                 contentExplorerScreen));
 
         doNothing().when(kieWorkbenchEntryPoint).hideLoadingPopup();
+
+        navTreeEditor = spy(new NavTreeEditor(mock(NavTreeEditor.View.class), syncBeanManager, perspectiveTreeProvider));
         when(contentExplorerScreen.getNavTreeEditor()).thenReturn(navTreeEditor);
     }
 
@@ -130,11 +140,11 @@ public class KieWorkbenchEntryPointTest {
 
         verify(workbench).addStartupBlocker(KieWorkbenchEntryPoint.class);
         verify(permissionTreeSetup).configureTree();
-        verify(navTreeEditor).setMaxLevels(NavTreeDefinitions.GROUP_WORKBENCH,
-                                           2);
-        verify(navTreeEditor).setNewDividerEnabled(false);
-        verify(navTreeEditor).setNewPerspectiveEnabled(NavTreeDefinitions.GROUP_WORKBENCH,
-                                                       false);
+        verify(navTreeEditor).setMaxLevels(NavTreeDefinitions.GROUP_WORKBENCH, 2);
+        verify(navTreeEditor).setNewDividerEnabled(NavTreeDefinitions.GROUP_WORKBENCH, false);
+        verify(navTreeEditor).setNewPerspectiveEnabled(NavTreeDefinitions.GROUP_WORKBENCH, false);
+        verify(navTreeEditor).setOnlyRuntimePerspectives(NavTreeDefinitions.GROUP_WORKBENCH, false);
+        verify(navTreeEditor).setPerspectiveContextEnabled(NavTreeDefinitions.GROUP_WORKBENCH, false);
     }
 
     @Test


### PR DESCRIPTION
@ederign can you please review and merge?

These changes are required in order to fix the nav config of the Workbench tree used by the Mega menu. It is part of the changes related to the new navigation features.