### PR TITLE
JBPM-6376 - Review GWT compiler classpath

### DIFF
--- a/kie-drools-wb-parent/kie-drools-wb-webapp/pom.xml
+++ b/kie-drools-wb-parent/kie-drools-wb-webapp/pom.xml
@@ -137,10 +137,12 @@
     <dependency>
       <groupId>org.kie.server</groupId>
       <artifactId>kie-server-controller-websocket</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.kie.server</groupId>
       <artifactId>kie-server-controller-websocket-common</artifactId>
+      <scope>runtime</scope>
     </dependency>
 
     <dependency>
@@ -166,12 +168,14 @@
     <dependency>
       <groupId>org.kie.workbench.screens</groupId>
       <artifactId>kie-wb-common-library-backend</artifactId>
+      <scope>runtime</scope>
     </dependency>
 
     <!-- identity provider -->
     <dependency>
       <groupId>org.kie</groupId>
       <artifactId>kie-identity-session-provider</artifactId>
+      <scope>runtime</scope>
       <exclusions>
         <exclusion>
           <groupId>javax.el</groupId>
@@ -206,6 +210,12 @@
     <dependency>
       <groupId>org.drools</groupId>
       <artifactId>drools-workbench-models-guided-scorecard</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>stax</groupId>
+          <artifactId>stax-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.drools</groupId>
@@ -252,6 +262,7 @@
     <dependency>
       <groupId>org.guvnor</groupId>
       <artifactId>guvnor-structure-backend</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.guvnor</groupId>
@@ -274,6 +285,7 @@
     <dependency>
       <groupId>org.guvnor</groupId>
       <artifactId>guvnor-m2repo-editor-backend</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.guvnor</groupId>
@@ -287,6 +299,7 @@
     <dependency>
       <groupId>org.guvnor</groupId>
       <artifactId>guvnor-project-backend</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.guvnor</groupId>
@@ -308,6 +321,7 @@
     <dependency>
       <groupId>org.guvnor</groupId>
       <artifactId>guvnor-message-console-backend</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.guvnor</groupId>
@@ -322,6 +336,7 @@
     <dependency>
       <groupId>org.guvnor</groupId>
       <artifactId>guvnor-services-backend</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.guvnor</groupId>
@@ -335,6 +350,7 @@
     <dependency>
       <groupId>org.guvnor</groupId>
       <artifactId>guvnor-asset-mgmt-backend</artifactId>
+      <scope>runtime</scope>
     </dependency>
 
     <!-- Guvnor ALA -->
@@ -345,6 +361,7 @@
     <dependency>
       <groupId>org.guvnor</groupId>
       <artifactId>guvnor-ala-ui-backend</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.guvnor</groupId>
@@ -363,26 +380,32 @@
     <dependency>
       <groupId>org.guvnor</groupId>
       <artifactId>guvnor-ala-openshift-ui-backend</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.guvnor</groupId>
       <artifactId>guvnor-ala-openshift-provider</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.guvnor</groupId>
       <artifactId>guvnor-ala-registry-vfs</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.guvnor</groupId>
       <artifactId>guvnor-ala-services-backend</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.guvnor</groupId>
       <artifactId>guvnor-ala-services-rest</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.guvnor</groupId>
       <artifactId>guvnor-ala-provisioning-pipelines-openshift</artifactId>
+      <scope>runtime</scope>
     </dependency>
 
     <!-- Common -->
@@ -399,10 +422,12 @@
     <dependency>
       <groupId>org.kie.workbench.services</groupId>
       <artifactId>kie-wb-common-datamodel-backend</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.kie.workbench.services</groupId>
       <artifactId>kie-wb-common-refactoring-backend</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.kie.workbench.services</groupId>
@@ -421,6 +446,11 @@
     <dependency>
       <groupId>org.kie.workbench.services</groupId>
       <artifactId>kie-wb-common-services-backend</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.kie.workbench.screens</groupId>
+      <artifactId>kie-wb-common-project-editor-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.kie.workbench.screens</groupId>
@@ -430,6 +460,7 @@
     <dependency>
       <groupId>org.kie.workbench.screens</groupId>
       <artifactId>kie-wb-common-project-editor-backend</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.kie.workbench.screens</groupId>
@@ -448,6 +479,7 @@
     <dependency>
       <groupId>org.kie.workbench.screens</groupId>
       <artifactId>kie-wb-common-project-explorer-backend</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.kie.workbench.screens</groupId>
@@ -460,21 +492,31 @@
     </dependency>
     <dependency>
       <groupId>org.kie.workbench.screens</groupId>
+      <artifactId>kie-wb-common-default-editor-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.kie.workbench.screens</groupId>
       <artifactId>kie-wb-common-default-editor-client</artifactId>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.kie.workbench.screens</groupId>
       <artifactId>kie-wb-common-default-editor-backend</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.kie.workbench.screens</groupId>
       <artifactId>kie-wb-common-server-ui-backend</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.kie.workbench.screens</groupId>
       <artifactId>kie-wb-common-server-ui-client</artifactId>
       <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.kie.workbench.screens</groupId>
+      <artifactId>kie-wb-common-server-ui-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.kie.workbench.screens</groupId>
@@ -488,10 +530,12 @@
     <dependency>
       <groupId>org.kie.workbench.screens</groupId>
       <artifactId>kie-wb-common-contributors-backend</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.kie.workbench.screens</groupId>
       <artifactId>kie-wb-common-social-home-page-backend</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.kie.workbench.screens</groupId>
@@ -513,6 +557,7 @@
     <dependency>
       <groupId>org.kie.workbench.screens</groupId>
       <artifactId>kie-wb-common-data-modeller-backend</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.kie.workbench.screens</groupId>
@@ -531,6 +576,7 @@
     <dependency>
       <groupId>org.kie.workbench.screens</groupId>
       <artifactId>kie-wb-common-examples-screen-backend</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.kie.workbench.screens</groupId>
@@ -554,33 +600,52 @@
     <dependency>
       <groupId>org.kie.workbench.screens</groupId>
       <artifactId>kie-wb-common-datasource-mgmt-backend</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.kie.workbench.screens</groupId>
       <artifactId>kie-wb-common-datasource-mgmt-wildfly</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.kie.workbench.screens</groupId>
       <artifactId>kie-wb-common-datasource-mgmt-dbcp</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.kie.workbench.screens</groupId>
       <artifactId>kie-wb-common-datasource-mgmt-dashbuilder</artifactId>
+      <scope>runtime</scope>
     </dependency>
 
     <!-- KIE Workbench Playground Repository -->
     <dependency>
       <groupId>org.kie.workbench.playground</groupId>
       <artifactId>playground-parent</artifactId>
+      <scope>runtime</scope>
     </dependency>
 
     <!-- Drools Workbench Services -->
     <dependency>
       <groupId>org.drools</groupId>
       <artifactId>drools-wb-verifier-backend</artifactId>
+      <scope>runtime</scope>
     </dependency>
 
     <!-- Drools Workbench Screens -->
+    <dependency>
+      <groupId>org.drools</groupId>
+      <artifactId>drools-wb-verifier-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.drools</groupId>
+      <artifactId>drools-wb-verifier-client</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.drools</groupId>
+      <artifactId>drools-wb-guided-rule-editor-api</artifactId>
+    </dependency>
     <dependency>
       <groupId>org.drools</groupId>
       <artifactId>drools-wb-guided-rule-editor-client</artifactId>
@@ -589,6 +654,11 @@
     <dependency>
       <groupId>org.drools</groupId>
       <artifactId>drools-wb-guided-rule-editor-backend</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.drools</groupId>
+      <artifactId>drools-wb-guided-template-editor-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.drools</groupId>
@@ -598,6 +668,11 @@
     <dependency>
       <groupId>org.drools</groupId>
       <artifactId>drools-wb-guided-template-editor-backend</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.drools</groupId>
+      <artifactId>drools-wb-guided-dtable-editor-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.drools</groupId>
@@ -607,6 +682,11 @@
     <dependency>
       <groupId>org.drools</groupId>
       <artifactId>drools-wb-guided-dtable-editor-backend</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.drools</groupId>
+      <artifactId>drools-wb-guided-dtree-editor-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.drools</groupId>
@@ -616,6 +696,11 @@
     <dependency>
       <groupId>org.drools</groupId>
       <artifactId>drools-wb-guided-dtree-editor-backend</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.drools</groupId>
+      <artifactId>drools-wb-guided-scorecard-editor-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.drools</groupId>
@@ -625,6 +710,11 @@
     <dependency>
       <groupId>org.drools</groupId>
       <artifactId>drools-wb-guided-scorecard-editor-backend</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.drools</groupId>
+      <artifactId>drools-wb-drl-text-editor-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.drools</groupId>
@@ -634,6 +724,11 @@
     <dependency>
       <groupId>org.drools</groupId>
       <artifactId>drools-wb-drl-text-editor-backend</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.drools</groupId>
+      <artifactId>drools-wb-enum-editor-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.drools</groupId>
@@ -643,10 +738,20 @@
     <dependency>
       <groupId>org.drools</groupId>
       <artifactId>drools-wb-enum-editor-backend</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.drools</groupId>
+      <artifactId>drools-wb-factmodel-editor-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.drools</groupId>
       <artifactId>drools-wb-factmodel-editor-backend</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.drools</groupId>
+      <artifactId>drools-wb-dsl-text-editor-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.drools</groupId>
@@ -656,6 +761,11 @@
     <dependency>
       <groupId>org.drools</groupId>
       <artifactId>drools-wb-dsl-text-editor-backend</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.drools</groupId>
+      <artifactId>drools-wb-dtable-xls-editor-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.drools</groupId>
@@ -665,6 +775,11 @@
     <dependency>
       <groupId>org.drools</groupId>
       <artifactId>drools-wb-dtable-xls-editor-backend</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.drools</groupId>
+      <artifactId>drools-wb-scorecard-xls-editor-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.drools</groupId>
@@ -674,6 +789,7 @@
     <dependency>
       <groupId>org.drools</groupId>
       <artifactId>drools-wb-scorecard-xls-editor-backend</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.drools</groupId>
@@ -687,6 +803,11 @@
     <dependency>
       <groupId>org.drools</groupId>
       <artifactId>drools-wb-globals-editor-backend</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.drools</groupId>
+      <artifactId>drools-wb-test-scenario-editor-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.drools</groupId>
@@ -696,6 +817,7 @@
     <dependency>
       <groupId>org.drools</groupId>
       <artifactId>drools-wb-test-scenario-editor-backend</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.drools</groupId>
@@ -726,10 +848,12 @@
     <dependency>
       <groupId>org.optaplanner</groupId>
       <artifactId>optaplanner-wb-domain-editor-backend</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.optaplanner</groupId>
       <artifactId>optaplanner-wb-guided-rule-editor-backend</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.optaplanner</groupId>
@@ -752,6 +876,7 @@
     <dependency>
       <groupId>org.optaplanner</groupId>
       <artifactId>optaplanner-wb-solver-editor-backend</artifactId>
+      <scope>runtime</scope>
     </dependency>
 
     <!-- jBPM Designer -->
@@ -767,6 +892,7 @@
     <dependency>
       <groupId>org.jbpm</groupId>
       <artifactId>jbpm-designer-backend</artifactId>
+      <scope>runtime</scope>
       <exclusions>
         <exclusion>
           <groupId>org.jbpm</groupId>
@@ -793,6 +919,10 @@
           <artifactId>jbpm-workitems-webservice</artifactId>
         </exclusion>
       </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>batik</groupId>
+      <artifactId>batik-ext</artifactId>
     </dependency>
 
     <!-- org.dashbuilder -->
@@ -908,6 +1038,10 @@
     </dependency>
     <dependency>
       <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-maven-integration</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.uberfire</groupId>
       <artifactId>uberfire-commons</artifactId>
     </dependency>
     <dependency>
@@ -945,6 +1079,7 @@
     <dependency>
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-servlet-security</artifactId>
+      <scope>runtime</scope>
     </dependency>
 
     <!-- UberFire Preferences Extension -->
@@ -976,6 +1111,7 @@
     <dependency>
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-runtime-plugins-backend</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.uberfire</groupId>
@@ -1003,12 +1139,17 @@
     <!-- UberFire Apps -->
     <dependency>
       <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-apps-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.uberfire</groupId>
       <artifactId>uberfire-apps-client</artifactId>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-apps-backend</artifactId>
+      <scope>runtime</scope>
     </dependency>
 
     <!-- UF Extensions -->
@@ -1032,6 +1173,7 @@
     <dependency>
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-metadata-backend-lucene</artifactId>
+      <scope>runtime</scope>
       <exclusions>
         <exclusion>
           <groupId>jakarta-regexp</groupId>
@@ -1042,10 +1184,12 @@
     <dependency>
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-metadata-commons-io</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.lucene</groupId>
       <artifactId>lucene-core</artifactId>
+      <scope>runtime</scope>
     </dependency>
 
     <!-- Other UberFire -->
@@ -1067,6 +1211,7 @@
     <dependency>
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-widgets-service-backend</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.uberfire</groupId>
@@ -1086,6 +1231,7 @@
     <dependency>
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-backend-server</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.uberfire</groupId>
@@ -1096,6 +1242,11 @@
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-client-all</artifactId>
       <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-server-all</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.uberfire</groupId>
@@ -1173,11 +1324,21 @@
       <groupId>org.jboss.errai</groupId>
       <artifactId>errai-cdi-server</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.jboss.errai</groupId>
+      <artifactId>errai-jaxrs-client</artifactId>
+      <scope>provided</scope>
+    </dependency>
 
     <!-- GWT and GWT Extensions -->
     <dependency>
       <groupId>de.benediktmeurer.gwt-slf4j</groupId>
       <artifactId>gwt-slf4j</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mozilla</groupId>
+      <artifactId>rhino</artifactId>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -1190,6 +1351,11 @@
           <artifactId>sac</artifactId>
         </exclusion>
       </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>com.google.inject</groupId>
+      <artifactId>guice</artifactId>
+      <classifier>no_aop</classifier>
     </dependency>
 
     <dependency>
@@ -1219,6 +1385,7 @@
     <dependency>
       <groupId>org.guvnor</groupId>
       <artifactId>guvnor-rest-backend</artifactId>
+      <scope>runtime</scope>
     </dependency>
 
     <!-- Form Modeler dependencies -->
@@ -1246,12 +1413,14 @@
     <dependency>
       <groupId>org.jbpm</groupId>
       <artifactId>jbpm-form-modeler-renderer-backend</artifactId>
+      <scope>runtime</scope>
     </dependency>
 
 
     <dependency>
       <groupId>org.kie.uberfire</groupId>
       <artifactId>i18n-taglib</artifactId>
+      <scope>runtime</scope>
     </dependency>
 
     <!-- hack to disable sisu annotation processing (that scans client side types) -->
@@ -1271,6 +1440,7 @@
     <dependency>
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-security-management-backend</artifactId>
+      <scope>runtime</scope>
     </dependency>
 
     <dependency>
@@ -1295,6 +1465,7 @@
     <dependency>
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-security-management-wildfly</artifactId>
+      <scope>runtime</scope>
     </dependency>
 
     <!-- Validation -->
@@ -1360,6 +1531,7 @@
     <dependency>
       <groupId>org.kie.workbench.forms</groupId>
       <artifactId>kie-wb-common-forms-adf-engine-backend</artifactId>
+      <scope>runtime</scope>
     </dependency>
 
     <dependency>
@@ -1382,6 +1554,7 @@
     <dependency>
       <groupId>org.kie.workbench.forms</groupId>
       <artifactId>kie-wb-common-dynamic-forms-backend</artifactId>
+      <scope>runtime</scope>
     </dependency>
 
     <dependency>
@@ -1409,6 +1582,7 @@
     <dependency>
       <groupId>org.kie.workbench.forms</groupId>
       <artifactId>kie-wb-common-forms-editor-backend</artifactId>
+      <scope>runtime</scope>
     </dependency>
 
     <!-- Stunner and BPMN set. -->
@@ -1446,6 +1620,7 @@
     <dependency>
       <groupId>org.kie.workbench.stunner</groupId>
       <artifactId>kie-wb-common-stunner-backend</artifactId>
+      <scope>runtime</scope>
     </dependency>
 
     <dependency>
@@ -1520,6 +1695,7 @@
     <dependency>
       <groupId>org.kie.workbench.stunner</groupId>
       <artifactId>kie-wb-common-stunner-bpmn-backend</artifactId>
+      <scope>runtime</scope>
     </dependency>
 
     <dependency>
@@ -1547,6 +1723,7 @@
     <dependency>
       <groupId>org.kie.workbench.stunner</groupId>
       <artifactId>kie-wb-common-stunner-forms-backend</artifactId>
+      <scope>runtime</scope>
     </dependency>
 
     <dependency>
@@ -1563,6 +1740,7 @@
     <dependency>
       <groupId>org.kie.workbench.stunner</groupId>
       <artifactId>kie-wb-common-stunner-project-backend</artifactId>
+      <scope>runtime</scope>
     </dependency>
 
     <dependency>

--- a/kie-wb-parent/kie-wb-monitoring-webapp/pom.xml
+++ b/kie-wb-parent/kie-wb-monitoring-webapp/pom.xml
@@ -120,6 +120,7 @@
     <dependency>
       <groupId>org.kie</groupId>
       <artifactId>kie-identity-session-provider</artifactId>
+      <scope>runtime</scope>
       <exclusions>
         <exclusion>
           <groupId>javax.el</groupId>
@@ -136,6 +137,7 @@
     <dependency>
       <groupId>org.kie</groupId>
       <artifactId>kie-security</artifactId>
+      <scope>runtime</scope>
     </dependency>
 
     <!-- Logging -->
@@ -153,10 +155,12 @@
     <dependency>
       <groupId>org.jbpm</groupId>
       <artifactId>jbpm-wb-human-tasks-backend</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.jbpm</groupId>
       <artifactId>jbpm-wb-kie-server-backend</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.jbpm</groupId>
@@ -166,6 +170,7 @@
     <dependency>
       <groupId>org.jbpm</groupId>
       <artifactId>jbpm-wb-process-runtime-backend</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.jbpm</groupId>
@@ -175,6 +180,7 @@
     <dependency>
       <groupId>org.jbpm</groupId>
       <artifactId>jbpm-wb-executor-service-backend</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.jbpm</groupId>
@@ -193,6 +199,7 @@
     <dependency>
       <groupId>org.jbpm</groupId>
       <artifactId>jbpm-wb-forms-backend</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.jbpm</groupId>
@@ -201,6 +208,7 @@
     <dependency>
       <groupId>org.jbpm</groupId>
       <artifactId>jbpm-wb-dashboard-backend</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.jbpm</groupId>
@@ -222,10 +230,12 @@
     <dependency>
       <groupId>org.kie.server</groupId>
       <artifactId>kie-server-controller-websocket</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.kie.server</groupId>
       <artifactId>kie-server-controller-websocket-common</artifactId>
+      <scope>runtime</scope>
     </dependency>
 
     <!-- Guvnor -->
@@ -245,6 +255,7 @@
     <dependency>
       <groupId>org.guvnor</groupId>
       <artifactId>guvnor-services-backend</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.guvnor</groupId>
@@ -258,6 +269,7 @@
     <dependency>
       <groupId>org.guvnor</groupId>
       <artifactId>guvnor-m2repo-editor-backend</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.guvnor</groupId>
@@ -290,6 +302,7 @@
     <dependency>
       <groupId>org.guvnor</groupId>
       <artifactId>guvnor-ala-ui-backend</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.guvnor</groupId>
@@ -308,22 +321,27 @@
     <dependency>
       <groupId>org.guvnor</groupId>
       <artifactId>guvnor-ala-openshift-ui-backend</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.guvnor</groupId>
       <artifactId>guvnor-ala-openshift-provider</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.guvnor</groupId>
       <artifactId>guvnor-ala-registry-vfs</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.guvnor</groupId>
       <artifactId>guvnor-ala-services-backend</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.guvnor</groupId>
       <artifactId>guvnor-ala-services-rest</artifactId>
+      <scope>runtime</scope>
     </dependency>
 
     <!-- Common -->
@@ -368,6 +386,7 @@
     <dependency>
       <groupId>org.kie.workbench.screens</groupId>
       <artifactId>kie-wb-common-project-explorer-backend</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.kie.workbench.screens</groupId>
@@ -381,6 +400,7 @@
     <dependency>
       <groupId>org.kie.workbench.screens</groupId>
       <artifactId>kie-wb-common-server-ui-backend</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.kie.workbench.screens</groupId>
@@ -407,6 +427,7 @@
     <dependency>
       <groupId>org.kie.workbench.screens</groupId>
       <artifactId>kie-wb-common-examples-screen-backend</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.kie.workbench.screens</groupId>
@@ -415,6 +436,7 @@
     <dependency>
       <groupId>org.kie.workbench.screens</groupId>
       <artifactId>kie-wb-common-workbench-backend</artifactId>
+      <scope>runtime</scope>
     </dependency>
 
     <!-- Datasource management -->
@@ -430,18 +452,22 @@
     <dependency>
       <groupId>org.kie.workbench.screens</groupId>
       <artifactId>kie-wb-common-datasource-mgmt-backend</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.kie.workbench.screens</groupId>
       <artifactId>kie-wb-common-datasource-mgmt-wildfly</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.kie.workbench.screens</groupId>
       <artifactId>kie-wb-common-datasource-mgmt-dbcp</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.kie.workbench.screens</groupId>
       <artifactId>kie-wb-common-datasource-mgmt-dashbuilder</artifactId>
+      <scope>runtime</scope>
     </dependency>
 
     <!-- Errai -->
@@ -516,15 +542,14 @@
 
     <!-- GWT and GWT Extensions -->
     <dependency>
+      <groupId>org.mozilla</groupId>
+      <artifactId>rhino</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>com.google.gwt</groupId>
       <artifactId>gwt-user</artifactId>
       <scope>provided</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>org.w3c.css</groupId>
-          <artifactId>sac</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.gwtbootstrap3</groupId>
@@ -553,6 +578,7 @@
     <dependency>
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-backend-server</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.uberfire</groupId>
@@ -563,6 +589,11 @@
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-client-all</artifactId>
       <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-server-all</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.uberfire</groupId>
@@ -577,6 +608,10 @@
     <dependency>
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-maven-support</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-maven-integration</artifactId>
     </dependency>
     <dependency>
       <groupId>org.uberfire</groupId>
@@ -623,6 +658,7 @@
     <dependency>
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-widgets-service-backend</artifactId>
+      <scope>runtime</scope>
     </dependency>
 
     <!-- UberFire Security (Extension) -->
@@ -638,6 +674,7 @@
     <dependency>
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-servlet-security</artifactId>
+      <scope>runtime</scope>
     </dependency>
 
     <!-- UberFire Preferences Extension -->
@@ -648,6 +685,7 @@
     <dependency>
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-preferences-backend</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.uberfire</groupId>
@@ -669,6 +707,7 @@
     <dependency>
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-runtime-plugins-backend</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.uberfire</groupId>
@@ -685,6 +724,7 @@
     <dependency>
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-apps-backend</artifactId>
+      <scope>runtime</scope>
     </dependency>
 
     <!-- Layout Editor API -->
@@ -697,6 +737,7 @@
     <dependency>
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-metadata-backend-lucene</artifactId>
+      <scope>runtime</scope>
       <exclusions>
         <exclusion>
           <groupId>jakarta-regexp</groupId>
@@ -707,10 +748,12 @@
     <dependency>
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-metadata-commons-io</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.lucene</groupId>
       <artifactId>lucene-core</artifactId>
+      <scope>runtime</scope>
     </dependency>
 
     <!-- Uberfire Docks extension -->
@@ -765,6 +808,7 @@
     <dependency>
       <groupId>org.jbpm</groupId>
       <artifactId>jbpm-form-modeler-renderer-backend</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.jbpm</groupId>
@@ -778,6 +822,7 @@
     <dependency>
       <groupId>org.jbpm</groupId>
       <artifactId>jbpm-form-modeler-editor-backend</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.jbpm</groupId>
@@ -795,6 +840,7 @@
     <dependency>
       <groupId>org.jbpm</groupId>
       <artifactId>jbpm-wb-forms-modeler-backend</artifactId>
+      <scope>runtime</scope>
     </dependency>
 
     <dependency>
@@ -833,6 +879,7 @@
     <dependency>
       <groupId>org.dashbuilder</groupId>
       <artifactId>dashbuilder-services</artifactId>
+      <scope>runtime</scope>
     </dependency>
 
     <dependency>
@@ -898,6 +945,7 @@
     <dependency>
       <groupId>org.dashbuilder</groupId>
       <artifactId>dashbuilder-navigation-backend</artifactId>
+      <scope>runtime</scope>
     </dependency>
 
     <dependency>
@@ -997,6 +1045,7 @@
     <dependency>
       <groupId>org.kie.uberfire</groupId>
       <artifactId>i18n-taglib</artifactId>
+      <scope>runtime</scope>
     </dependency>
 
     <!-- hack to disable sisu annotation processing (that scans client side types) -->
@@ -1015,6 +1064,7 @@
     <dependency>
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-security-management-backend</artifactId>
+      <scope>runtime</scope>
     </dependency>
 
     <dependency>
@@ -1039,6 +1089,7 @@
     <dependency>
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-security-management-wildfly</artifactId>
+      <scope>runtime</scope>
     </dependency>
 
     <!-- Validation -->
@@ -1098,6 +1149,7 @@
     <dependency>
       <groupId>org.kie.workbench.forms</groupId>
       <artifactId>kie-wb-common-forms-adf-engine-backend</artifactId>
+      <scope>runtime</scope>
     </dependency>
 
     <dependency>
@@ -1114,12 +1166,18 @@
     <dependency>
       <groupId>org.kie.workbench.forms</groupId>
       <artifactId>kie-wb-common-dynamic-forms-backend</artifactId>
+      <scope>runtime</scope>
     </dependency>
 
     <dependency>
       <groupId>org.kie.workbench.forms</groupId>
       <artifactId>kie-wb-common-dynamic-forms-client</artifactId>
       <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.kie.workbench.forms</groupId>
+      <artifactId>kie-wb-common-forms-editor-api</artifactId>
     </dependency>
 
     <dependency>
@@ -1169,6 +1227,7 @@
     <dependency>
       <groupId>org.kie.workbench.forms</groupId>
       <artifactId>kie-wb-common-forms-jbpm-integration-backend</artifactId>
+      <scope>runtime</scope>
     </dependency>
 
     <dependency>
@@ -1190,6 +1249,7 @@
     <dependency>
       <groupId>org.kie.workbench.screens</groupId>
       <artifactId>kie-wb-common-library-backend</artifactId>
+      <scope>runtime</scope>
     </dependency>
 
     <!-- Test deps -->

--- a/kie-wb-parent/kie-wb-webapp/pom.xml
+++ b/kie-wb-parent/kie-wb-webapp/pom.xml
@@ -46,6 +46,7 @@
       </exclusions>
     </dependency>
 
+    <!-- Specs -->
     <dependency>
       <groupId>org.jboss.spec.javax.annotation</groupId>
       <artifactId>jboss-annotations-api_1.2_spec</artifactId>
@@ -132,6 +133,7 @@
     <dependency>
       <groupId>org.kie</groupId>
       <artifactId>kie-identity-session-provider</artifactId>
+      <scope>runtime</scope>
       <exclusions>
         <exclusion>
           <groupId>javax.el</groupId>
@@ -148,6 +150,7 @@
     <dependency>
       <groupId>org.kie</groupId>
       <artifactId>kie-security</artifactId>
+      <scope>runtime</scope>
     </dependency>
 
     <!-- Logging -->
@@ -165,10 +168,12 @@
     <dependency>
       <groupId>org.jbpm</groupId>
       <artifactId>jbpm-wb-human-tasks-backend</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.jbpm</groupId>
       <artifactId>jbpm-wb-kie-server-backend</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.jbpm</groupId>
@@ -178,6 +183,7 @@
     <dependency>
       <groupId>org.jbpm</groupId>
       <artifactId>jbpm-wb-process-runtime-backend</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.jbpm</groupId>
@@ -187,6 +193,7 @@
     <dependency>
       <groupId>org.jbpm</groupId>
       <artifactId>jbpm-wb-executor-service-backend</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.jbpm</groupId>
@@ -205,6 +212,7 @@
     <dependency>
       <groupId>org.jbpm</groupId>
       <artifactId>jbpm-wb-forms-backend</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.jbpm</groupId>
@@ -214,6 +222,7 @@
     <dependency>
       <groupId>org.jbpm</groupId>
       <artifactId>jbpm-wb-integration-backend</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.jbpm</groupId>
@@ -222,6 +231,7 @@
     <dependency>
       <groupId>org.jbpm</groupId>
       <artifactId>jbpm-wb-dashboard-backend</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.jbpm</groupId>
@@ -243,16 +253,19 @@
     <dependency>
       <groupId>org.kie.server</groupId>
       <artifactId>kie-server-controller-websocket</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.kie.server</groupId>
       <artifactId>kie-server-controller-websocket-common</artifactId>
+      <scope>runtime</scope>
     </dependency>
 
     <!-- Guvnor REST -->
     <dependency>
       <groupId>org.guvnor</groupId>
       <artifactId>guvnor-rest-backend</artifactId>
+      <scope>runtime</scope>
     </dependency>
 
     <!-- Models held within Drools -->
@@ -271,6 +284,12 @@
     <dependency>
       <groupId>org.drools</groupId>
       <artifactId>drools-workbench-models-guided-scorecard</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>stax</groupId>
+          <artifactId>stax-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.drools</groupId>
@@ -289,6 +308,7 @@
     <dependency>
       <groupId>org.guvnor</groupId>
       <artifactId>guvnor-structure-backend</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.guvnor</groupId>
@@ -302,6 +322,7 @@
     <dependency>
       <groupId>org.guvnor</groupId>
       <artifactId>guvnor-services-backend</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.guvnor</groupId>
@@ -315,6 +336,7 @@
     <dependency>
       <groupId>org.guvnor</groupId>
       <artifactId>guvnor-m2repo-editor-backend</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.guvnor</groupId>
@@ -328,6 +350,7 @@
     <dependency>
       <groupId>org.guvnor</groupId>
       <artifactId>guvnor-project-backend</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.guvnor</groupId>
@@ -349,6 +372,7 @@
     <dependency>
       <groupId>org.guvnor</groupId>
       <artifactId>guvnor-message-console-backend</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.guvnor</groupId>
@@ -368,6 +392,7 @@
     <dependency>
       <groupId>org.guvnor</groupId>
       <artifactId>guvnor-asset-mgmt-backend</artifactId>
+      <scope>runtime</scope>
     </dependency>
 
     <!-- Guvnor ALA -->
@@ -378,6 +403,7 @@
     <dependency>
       <groupId>org.guvnor</groupId>
       <artifactId>guvnor-ala-ui-backend</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.guvnor</groupId>
@@ -396,26 +422,32 @@
     <dependency>
       <groupId>org.guvnor</groupId>
       <artifactId>guvnor-ala-openshift-ui-backend</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.guvnor</groupId>
       <artifactId>guvnor-ala-openshift-provider</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.guvnor</groupId>
       <artifactId>guvnor-ala-registry-vfs</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.guvnor</groupId>
       <artifactId>guvnor-ala-services-backend</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.guvnor</groupId>
       <artifactId>guvnor-ala-services-rest</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.guvnor</groupId>
       <artifactId>guvnor-ala-provisioning-pipelines-openshift</artifactId>
+      <scope>runtime</scope>
     </dependency>
 
     <!-- Common -->
@@ -432,6 +464,7 @@
     <dependency>
       <groupId>org.kie.workbench.services</groupId>
       <artifactId>kie-wb-common-datamodel-backend</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.kie.workbench.widgets</groupId>
@@ -445,10 +478,12 @@
     <dependency>
       <groupId>org.kie.workbench.services</groupId>
       <artifactId>kie-wb-common-services-backend</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.kie.workbench.services</groupId>
       <artifactId>kie-wb-common-refactoring-backend</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.kie.workbench.services</groupId>
@@ -467,6 +502,7 @@
     <dependency>
       <groupId>org.kie.workbench.screens</groupId>
       <artifactId>kie-wb-common-project-editor-backend</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.kie.workbench.screens</groupId>
@@ -485,6 +521,7 @@
     <dependency>
       <groupId>org.kie.workbench.screens</groupId>
       <artifactId>kie-wb-common-project-explorer-backend</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.kie.workbench.screens</groupId>
@@ -503,10 +540,12 @@
     <dependency>
       <groupId>org.kie.workbench.screens</groupId>
       <artifactId>kie-wb-common-default-editor-backend</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.kie.workbench.screens</groupId>
       <artifactId>kie-wb-common-server-ui-backend</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.kie.workbench.screens</groupId>
@@ -525,10 +564,12 @@
     <dependency>
       <groupId>org.kie.workbench.screens</groupId>
       <artifactId>kie-wb-common-contributors-backend</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.kie.workbench.screens</groupId>
       <artifactId>kie-wb-common-social-home-page-backend</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.kie.workbench.screens</groupId>
@@ -546,6 +587,7 @@
     <dependency>
       <groupId>org.kie.workbench.screens</groupId>
       <artifactId>kie-wb-common-data-modeller-backend</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.kie.workbench.screens</groupId>
@@ -564,6 +606,7 @@
     <dependency>
       <groupId>org.kie.workbench.screens</groupId>
       <artifactId>kie-wb-common-examples-screen-backend</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.kie.workbench.screens</groupId>
@@ -587,33 +630,48 @@
     <dependency>
       <groupId>org.kie.workbench.screens</groupId>
       <artifactId>kie-wb-common-datasource-mgmt-backend</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.kie.workbench.screens</groupId>
       <artifactId>kie-wb-common-datasource-mgmt-wildfly</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.kie.workbench.screens</groupId>
       <artifactId>kie-wb-common-datasource-mgmt-dbcp</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.kie.workbench.screens</groupId>
       <artifactId>kie-wb-common-datasource-mgmt-dashbuilder</artifactId>
+      <scope>runtime</scope>
     </dependency>
 
     <!-- KIE Workbench Playground Repository -->
     <dependency>
       <groupId>org.kie.workbench.playground</groupId>
       <artifactId>playground-parent</artifactId>
+      <scope>runtime</scope>
     </dependency>
 
     <!-- Drools Workbench Services -->
     <dependency>
       <groupId>org.drools</groupId>
       <artifactId>drools-wb-verifier-backend</artifactId>
+      <scope>runtime</scope>
     </dependency>
 
     <!-- Drools Workbench Screens -->
+    <dependency>
+      <groupId>org.drools</groupId>
+      <artifactId>drools-wb-verifier-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.drools</groupId>
+      <artifactId>drools-wb-verifier-client</artifactId>
+      <scope>provided</scope>
+    </dependency>
     <dependency>
       <groupId>org.drools</groupId>
       <artifactId>drools-wb-guided-rule-editor-client</artifactId>
@@ -622,6 +680,7 @@
     <dependency>
       <groupId>org.drools</groupId>
       <artifactId>drools-wb-guided-rule-editor-backend</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.drools</groupId>
@@ -631,6 +690,7 @@
     <dependency>
       <groupId>org.drools</groupId>
       <artifactId>drools-wb-guided-template-editor-backend</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.drools</groupId>
@@ -640,6 +700,7 @@
     <dependency>
       <groupId>org.drools</groupId>
       <artifactId>drools-wb-guided-dtable-editor-backend</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.drools</groupId>
@@ -649,6 +710,7 @@
     <dependency>
       <groupId>org.drools</groupId>
       <artifactId>drools-wb-guided-dtree-editor-backend</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.drools</groupId>
@@ -658,6 +720,7 @@
     <dependency>
       <groupId>org.drools</groupId>
       <artifactId>drools-wb-guided-scorecard-editor-backend</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.drools</groupId>
@@ -667,6 +730,7 @@
     <dependency>
       <groupId>org.drools</groupId>
       <artifactId>drools-wb-drl-text-editor-backend</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.drools</groupId>
@@ -676,10 +740,12 @@
     <dependency>
       <groupId>org.drools</groupId>
       <artifactId>drools-wb-enum-editor-backend</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.drools</groupId>
       <artifactId>drools-wb-factmodel-editor-backend</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.drools</groupId>
@@ -689,6 +755,7 @@
     <dependency>
       <groupId>org.drools</groupId>
       <artifactId>drools-wb-dsl-text-editor-backend</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.drools</groupId>
@@ -698,6 +765,7 @@
     <dependency>
       <groupId>org.drools</groupId>
       <artifactId>drools-wb-dtable-xls-editor-backend</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.drools</groupId>
@@ -707,6 +775,7 @@
     <dependency>
       <groupId>org.drools</groupId>
       <artifactId>drools-wb-scorecard-xls-editor-backend</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.drools</groupId>
@@ -720,6 +789,7 @@
     <dependency>
       <groupId>org.drools</groupId>
       <artifactId>drools-wb-globals-editor-backend</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.drools</groupId>
@@ -729,6 +799,7 @@
     <dependency>
       <groupId>org.drools</groupId>
       <artifactId>drools-wb-test-scenario-editor-backend</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.drools</groupId>
@@ -759,10 +830,12 @@
     <dependency>
       <groupId>org.optaplanner</groupId>
       <artifactId>optaplanner-wb-domain-editor-backend</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.optaplanner</groupId>
       <artifactId>optaplanner-wb-guided-rule-editor-backend</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.optaplanner</groupId>
@@ -785,6 +858,7 @@
     <dependency>
       <groupId>org.optaplanner</groupId>
       <artifactId>optaplanner-wb-solver-editor-backend</artifactId>
+      <scope>runtime</scope>
     </dependency>
 
     <!-- Errai -->
@@ -856,8 +930,18 @@
       <groupId>org.jboss.errai</groupId>
       <artifactId>errai-cdi-server</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.jboss.errai</groupId>
+      <artifactId>errai-jaxrs-client</artifactId>
+      <scope>provided</scope>
+    </dependency>
 
     <!-- GWT and GWT Extensions -->
+    <dependency>
+      <groupId>org.mozilla</groupId>
+      <artifactId>rhino</artifactId>
+      <scope>provided</scope>
+    </dependency>
     <dependency>
       <groupId>com.google.gwt</groupId>
       <artifactId>gwt-user</artifactId>
@@ -893,6 +977,7 @@
     <dependency>
       <groupId>org.jbpm</groupId>
       <artifactId>jbpm-designer-backend</artifactId>
+      <scope>runtime</scope>
       <exclusions>
         <exclusion>
           <groupId>org.jbpm</groupId>
@@ -920,15 +1005,21 @@
         </exclusion>
       </exclusions>
     </dependency>
+    <dependency>
+      <groupId>batik</groupId>
+      <artifactId>batik-ext</artifactId>
+    </dependency>
 
     <!-- jBPM Workitems -->
     <dependency>
       <groupId>org.jbpm</groupId>
       <artifactId>jbpm-workitems-core</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.jbpm</groupId>
       <artifactId>jbpm-workitems-bpmn2</artifactId>
+      <scope>runtime</scope>
       <exclusions>
         <exclusion>
           <groupId>org.apache.cxf</groupId>
@@ -963,6 +1054,7 @@
     <dependency>
       <groupId>org.jbpm</groupId>
       <artifactId>jbpm-workitems-email</artifactId>
+      <scope>runtime</scope>
       <exclusions>
         <exclusion>
           <groupId>javax.mail</groupId>
@@ -977,6 +1069,7 @@
     <dependency>
       <groupId>org.jbpm</groupId>
       <artifactId>jbpm-workitems-rest</artifactId>
+      <scope>runtime</scope>
     </dependency>
 
     <!-- UberFire -->
@@ -995,6 +1088,7 @@
     <dependency>
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-backend-server</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.uberfire</groupId>
@@ -1005,6 +1099,11 @@
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-client-all</artifactId>
       <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-server-all</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.uberfire</groupId>
@@ -1019,6 +1118,10 @@
     <dependency>
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-maven-support</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-maven-integration</artifactId>
     </dependency>
     <dependency>
       <groupId>org.uberfire</groupId>
@@ -1065,6 +1168,7 @@
     <dependency>
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-widgets-service-backend</artifactId>
+      <scope>runtime</scope>
     </dependency>
 
     <!-- UberFire Security (Extension) -->
@@ -1080,6 +1184,7 @@
     <dependency>
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-servlet-security</artifactId>
+      <scope>runtime</scope>
     </dependency>
 
     <!-- UberFire Preferences Extension -->
@@ -1090,6 +1195,7 @@
     <dependency>
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-preferences-backend</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.uberfire</groupId>
@@ -1111,6 +1217,7 @@
     <dependency>
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-runtime-plugins-backend</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.uberfire</groupId>
@@ -1127,6 +1234,7 @@
     <dependency>
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-apps-backend</artifactId>
+      <scope>runtime</scope>
     </dependency>
 
     <!-- Layout Editor API -->
@@ -1134,10 +1242,12 @@
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-layout-editor-api</artifactId>
     </dependency>
+
     <!-- Search -->
     <dependency>
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-metadata-backend-lucene</artifactId>
+      <scope>runtime</scope>
       <exclusions>
         <exclusion>
           <groupId>jakarta-regexp</groupId>
@@ -1148,10 +1258,12 @@
     <dependency>
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-metadata-commons-io</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.lucene</groupId>
       <artifactId>lucene-core</artifactId>
+      <scope>runtime</scope>
     </dependency>
 
     <!-- Uberfire Docks extension -->
@@ -1206,6 +1318,7 @@
     <dependency>
       <groupId>org.jbpm</groupId>
       <artifactId>jbpm-form-modeler-renderer-backend</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.jbpm</groupId>
@@ -1219,6 +1332,7 @@
     <dependency>
       <groupId>org.jbpm</groupId>
       <artifactId>jbpm-form-modeler-editor-backend</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.jbpm</groupId>
@@ -1240,6 +1354,7 @@
     <dependency>
       <groupId>org.jbpm</groupId>
       <artifactId>jbpm-wb-forms-modeler-backend</artifactId>
+      <scope>runtime</scope>
     </dependency>
 
     <dependency>
@@ -1530,6 +1645,7 @@
     <dependency>
       <groupId>org.kie.uberfire</groupId>
       <artifactId>i18n-taglib</artifactId>
+      <scope>runtime</scope>
     </dependency>
 
     <!-- hack to disable sisu annotation processing (that scans client side types) -->
@@ -1548,6 +1664,7 @@
     <dependency>
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-security-management-backend</artifactId>
+      <scope>runtime</scope>
     </dependency>
 
     <dependency>
@@ -1572,6 +1689,7 @@
     <dependency>
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-security-management-wildfly</artifactId>
+      <scope>runtime</scope>
     </dependency>
 
     <!-- Validation -->
@@ -1631,6 +1749,7 @@
     <dependency>
       <groupId>org.kie.workbench.forms</groupId>
       <artifactId>kie-wb-common-forms-adf-engine-backend</artifactId>
+      <scope>runtime</scope>
     </dependency>
 
     <dependency>
@@ -1647,6 +1766,7 @@
     <dependency>
       <groupId>org.kie.workbench.forms</groupId>
       <artifactId>kie-wb-common-dynamic-forms-backend</artifactId>
+      <scope>runtime</scope>
     </dependency>
 
     <dependency>
@@ -1663,6 +1783,7 @@
     <dependency>
       <groupId>org.kie.workbench.forms</groupId>
       <artifactId>kie-wb-common-forms-editor-backend</artifactId>
+      <scope>runtime</scope>
     </dependency>
 
     <dependency>
@@ -1712,6 +1833,7 @@
     <dependency>
       <groupId>org.kie.workbench.forms</groupId>
       <artifactId>kie-wb-common-forms-data-modeller-integration-backend</artifactId>
+      <scope>runtime</scope>
     </dependency>
 
     <dependency>
@@ -1728,6 +1850,7 @@
     <dependency>
       <groupId>org.kie.workbench.forms</groupId>
       <artifactId>kie-wb-common-forms-jbpm-integration-backend</artifactId>
+      <scope>runtime</scope>
     </dependency>
 
     <dependency>
@@ -1765,6 +1888,7 @@
     <dependency>
       <groupId>org.kie.workbench.stunner</groupId>
       <artifactId>kie-wb-common-stunner-backend-common</artifactId>
+      <scope>runtime</scope>
     </dependency>
 
     <dependency>
@@ -1776,6 +1900,7 @@
     <dependency>
       <groupId>org.kie.workbench.stunner</groupId>
       <artifactId>kie-wb-common-stunner-backend</artifactId>
+      <scope>runtime</scope>
     </dependency>
 
     <dependency>
@@ -1850,6 +1975,7 @@
     <dependency>
       <groupId>org.kie.workbench.stunner</groupId>
       <artifactId>kie-wb-common-stunner-bpmn-backend</artifactId>
+      <scope>runtime</scope>
     </dependency>
 
     <dependency>
@@ -1877,6 +2003,7 @@
     <dependency>
       <groupId>org.kie.workbench.stunner</groupId>
       <artifactId>kie-wb-common-stunner-forms-backend</artifactId>
+      <scope>runtime</scope>
     </dependency>
 
     <dependency>
@@ -1893,6 +2020,7 @@
     <dependency>
       <groupId>org.kie.workbench.stunner</groupId>
       <artifactId>kie-wb-common-stunner-project-backend</artifactId>
+      <scope>runtime</scope>
     </dependency>
 
     <dependency>
@@ -1915,6 +2043,7 @@
     <dependency>
       <groupId>org.kie.workbench.screens</groupId>
       <artifactId>kie-wb-common-library-backend</artifactId>
+      <scope>runtime</scope>
     </dependency>
 
     <!-- Test deps -->


### PR DESCRIPTION
Move most backend dependencies to runtime scope, removing it from the GWT compiler classpath