### PR TITLE
[JBPM-6458] remove dependency on jboss-sasl module

### DIFF
--- a/kie-wb-webapp-common/src/main/webapp/META-INF/jboss-deployment-structure.xml
+++ b/kie-wb-webapp-common/src/main/webapp/META-INF/jboss-deployment-structure.xml
@@ -38,7 +38,6 @@
            WildFly/EAP provider for the user system management, as this webapp does by default. -->
       <module name="org.jboss.as.controller-client"/>
       <module name="org.jboss.as.domain-management"/>
-      <module name="org.jboss.sasl"/>
       <module name="org.jboss.msc"/>
       <module name="org.jboss.dmr"/>
       


### PR DESCRIPTION
jboss-sasl was replaced by wildfly-elytron in WildFly 11 / EAP 7.1+.
It was also a private module, so were warned. From now on the
wildfly-elytron will be bundled directly inside the WAR (WEB-INF/lib) to
avoid the same issue again in future.

Depends on https://github.com/AppFormer/uberfire/pull/854