### PR TITLE
DASHBUILDE-252: CMS perspective UI redesign

### DIFF
--- a/kie-drools-wb-parent/kie-drools-wb-webapp/src/main/java/org/kie/workbench/drools/client/KieDroolsWorkbenchEntryPoint.java
+++ b/kie-drools-wb-parent/kie-drools-wb-webapp/src/main/java/org/kie/workbench/drools/client/KieDroolsWorkbenchEntryPoint.java
@@ -22,7 +22,7 @@ import javax.inject.Inject;
 import org.dashbuilder.client.cms.screen.explorer.ContentExplorerScreen;
 import org.dashbuilder.client.navigation.NavigationManager;
 import org.dashbuilder.client.navigation.event.NavTreeChangedEvent;
-import org.dashbuilder.client.navigation.widget.NavTreeEditor;
+import org.dashbuilder.client.navigation.widget.editor.NavTreeEditor;
 import org.dashbuilder.navigation.NavTree;
 import org.guvnor.common.services.shared.config.AppConfigService;
 import org.jboss.errai.common.client.api.Caller;

--- a/kie-drools-wb-parent/kie-drools-wb-webapp/src/main/java/org/kie/workbench/drools/client/navigation/NavTreeDefinitions.java
+++ b/kie-drools-wb-parent/kie-drools-wb-webapp/src/main/java/org/kie/workbench/drools/client/navigation/NavTreeDefinitions.java
@@ -36,7 +36,6 @@ import static org.kie.workbench.common.workbench.client.PerspectiveIds.SERVER_MA
 @ApplicationScoped
 public class NavTreeDefinitions {
 
-    public static final String GROUP_ROOT = "root";
     public static final String GROUP_WORKBENCH = "wb_group";
 
     public static final String GROUP_DESIGN = "wb_group_design";
@@ -53,17 +52,11 @@ public class NavTreeDefinitions {
     private NavigationConstants i18n = NavigationConstants.INSTANCE;
 
     public NavTree buildDefaultNavTree() {
-        NavTreeBuilder builder = new NavTreeBuilder()
-                .group(GROUP_ROOT,
-                       i18n.navTreeRootName(),
-                       i18n.navTreeRootDescr(),
-                       false)
+        return new NavTreeBuilder()
                 .group(GROUP_WORKBENCH,
-                       i18n.navTreeWorkbenchName(),
-                       i18n.navTreeWorkbenchDescr(),
-                       false);
-
-        return builder
+                        i18n.navTreeWorkbenchName(),
+                        i18n.navTreeWorkbenchDescr(),
+                        false)
                 .group(GROUP_DESIGN,
                        i18n.navTreeDesignName(),
                        i18n.navTreeDesignDescr(),
@@ -103,7 +96,6 @@ public class NavTreeDefinitions {
                       i18n.navTreeBusinessDashboardsDescr(),
                       true,
                       perspective(APPS))
-                .endGroup()
                 .endGroup()
                 .endGroup()
                 .build();

--- a/kie-drools-wb-parent/kie-drools-wb-webapp/src/main/java/org/kie/workbench/drools/client/resources/i18n/NavigationConstants.java
+++ b/kie-drools-wb-parent/kie-drools-wb-webapp/src/main/java/org/kie/workbench/drools/client/resources/i18n/NavigationConstants.java
@@ -25,8 +25,6 @@ public interface NavigationConstants
 
     NavigationConstants INSTANCE = GWT.create(NavigationConstants.class);
 
-    String navTreeRootName();
-
     String navTreeWorkbenchName();
 
     String navTreeHomeName();
@@ -46,8 +44,6 @@ public interface NavigationConstants
     String navTreeTrackName();
 
     String navTreeBusinessDashboardsName();
-
-    String navTreeRootDescr();
 
     String navTreeWorkbenchDescr();
 

--- a/kie-drools-wb-parent/kie-drools-wb-webapp/src/main/resources/org/kie/workbench/drools/client/resources/i18n/NavigationConstants.properties
+++ b/kie-drools-wb-parent/kie-drools-wb-webapp/src/main/resources/org/kie/workbench/drools/client/resources/i18n/NavigationConstants.properties
@@ -14,7 +14,6 @@
 # limitations under the License.
 #
 
-navTreeRootName=Root
 navTreeWorkbenchName=Workbench
 navTreeHomeName=Home
 navTreeDesignName=Design
@@ -26,8 +25,7 @@ navTreeExecutionServersName=Execution Servers
 navTreeTrackName=Track
 navTreeBusinessDashboardsName=Business Dashboards
 
-navTreeRootDescr=The navigation root node
-navTreeWorkbenchDescr=The workbench top menu bar
+navTreeWorkbenchDescr=The navigation tree used to display the workbench''s top menu bar
 navTreeHomeDescr=Home page
 navTreeDesignDescr=Design
 navTreeProjectsDescr=Projects

--- a/kie-drools-wb-parent/kie-drools-wb-webapp/src/test/java/org/kie/workbench/drools/client/KieDroolsWorkbenchEntryPointTest.java
+++ b/kie-drools-wb-parent/kie-drools-wb-webapp/src/test/java/org/kie/workbench/drools/client/KieDroolsWorkbenchEntryPointTest.java
@@ -19,8 +19,11 @@ package org.kie.workbench.drools.client;
 import com.google.gwtmockito.GwtMockitoTestRunner;
 import org.dashbuilder.client.cms.screen.explorer.ContentExplorerScreen;
 import org.dashbuilder.client.navigation.NavigationManager;
+import org.dashbuilder.client.navigation.event.NavTreeLoadedEvent;
 import org.dashbuilder.client.navigation.impl.NavigationManagerImpl;
-import org.dashbuilder.client.navigation.widget.NavTreeEditor;
+import org.dashbuilder.client.navigation.widget.editor.NavTreeEditor;
+import org.dashbuilder.client.navigation.widget.editor.NavTreeEditorView;
+import org.dashbuilder.client.navigation.widget.editor.TargetPerspectiveEditor;
 import org.dashbuilder.navigation.NavGroup;
 import org.dashbuilder.navigation.NavItem;
 import org.dashbuilder.navigation.NavTree;
@@ -42,6 +45,7 @@ import org.uberfire.client.workbench.Workbench;
 import org.uberfire.client.workbench.widgets.menu.megamenu.WorkbenchMegaMenuPresenter;
 import org.uberfire.ext.security.management.client.ClientUserSystemManager;
 import org.uberfire.mocks.CallerMock;
+import org.uberfire.mocks.EventSourceMock;
 import org.uberfire.mvp.Command;
 import org.uberfire.workbench.model.menu.MenuFactory;
 
@@ -97,15 +101,19 @@ public class KieDroolsWorkbenchEntryPointTest {
     @Mock
     protected NavTreeEditor navTreeEditor;
 
+    @Mock
+    protected TargetPerspectiveEditor targetPerspectiveEditor;
+
+    @Mock
+    protected EventSourceMock<NavTreeLoadedEvent> navTreeLoadedEvent;
+
     private KieDroolsWorkbenchEntryPoint kieWorkbenchEntryPoint;
 
     @Before
     public void setup() {
         navTreeDefinitions = new NavTreeDefinitions();
         navigationManager = new NavigationManagerImpl(new CallerMock<>(navigationServices),
-                                                      null,
-                                                      null,
-                                                      null);
+                null, navTreeLoadedEvent, null, null);
 
         doAnswer(invocationOnMock -> {
             ((Command) invocationOnMock.getArguments()[0]).execute();
@@ -130,7 +138,7 @@ public class KieDroolsWorkbenchEntryPointTest {
 
         doNothing().when(kieWorkbenchEntryPoint).hideLoadingPopup();
 
-        navTreeEditor = spy(new NavTreeEditor(mock(NavTreeEditor.View.class), syncBeanManager, perspectiveTreeProvider));
+        navTreeEditor = spy(new NavTreeEditor(mock(NavTreeEditorView.class), null, syncBeanManager, null, perspectiveTreeProvider, targetPerspectiveEditor, null, null, null));
         when(contentExplorerScreen.getNavTreeEditor()).thenReturn(navTreeEditor);
     }
 

--- a/kie-drools-wb-parent/kie-drools-wb-webapp/src/test/java/org/kie/workbench/drools/client/navigation/NavTreeDefinitionsTest.java
+++ b/kie-drools-wb-parent/kie-drools-wb-webapp/src/test/java/org/kie/workbench/drools/client/navigation/NavTreeDefinitionsTest.java
@@ -46,13 +46,7 @@ public class NavTreeDefinitionsTest {
         final List<NavItem> rootItems = navTree.getRootItems();
         assertEquals(1, rootItems.size());
 
-        final NavGroup rootItem = (NavGroup) rootItems.get(0);
-        assertEquals(GROUP_ROOT, rootItem.getId());
-        assertEquals(false, rootItem.isModifiable());
-        final List<NavItem> rootChildren = rootItem.getChildren();
-        assertEquals(1, rootChildren.size());
-
-        final NavGroup workbenchItem = (NavGroup) rootChildren.get(0);
+        final NavGroup workbenchItem = (NavGroup) rootItems.get(0);
         assertEquals(GROUP_WORKBENCH, workbenchItem.getId());
         assertEquals(false, workbenchItem.isModifiable());
         final List<NavItem> workbenchChildren = workbenchItem.getChildren();

--- a/kie-wb-parent/kie-wb-monitoring-webapp/src/main/java/org/kie/workbench/client/navigation/NavTreeDefinitions.java
+++ b/kie-wb-parent/kie-wb-monitoring-webapp/src/main/java/org/kie/workbench/client/navigation/NavTreeDefinitions.java
@@ -30,7 +30,6 @@ import static org.kie.workbench.common.workbench.client.PerspectiveIds.*;
 @ApplicationScoped
 public class NavTreeDefinitions {
 
-    public static final String GROUP_ROOT = "root";
     public static final String GROUP_WORKBENCH = "wb_group";
 
     public static final String GROUP_DESIGN = "wb_group_design";
@@ -55,17 +54,11 @@ public class NavTreeDefinitions {
     private NavigationConstants i18n = NavigationConstants.INSTANCE;
 
     public NavTree buildDefaultNavTree() {
-        NavTreeBuilder builder = new NavTreeBuilder()
-                .group(GROUP_ROOT,
-                       i18n.navTreeRootName(),
-                       i18n.navTreeRootDescr(),
-                       false)
+        return new NavTreeBuilder()
                 .group(GROUP_WORKBENCH,
-                       i18n.navTreeWorkbenchName(),
-                       i18n.navTreeWorkbenchDescr(),
-                       false);
-
-        return builder
+                        i18n.navTreeWorkbenchName(),
+                        i18n.navTreeWorkbenchDescr(),
+                        false)
                 .group(GROUP_DESIGN,
                        i18n.navTreeDesignName(),
                        i18n.navTreeDesignDescr(),
@@ -140,7 +133,6 @@ public class NavTreeDefinitions {
                       i18n.navTreeBusinessDashboardsDescr(),
                       true,
                       perspective(APPS))
-                .endGroup()
                 .endGroup()
                 .endGroup()
                 .build();

--- a/kie-wb-parent/kie-wb-monitoring-webapp/src/main/java/org/kie/workbench/client/resources/i18n/NavigationConstants.java
+++ b/kie-wb-parent/kie-wb-monitoring-webapp/src/main/java/org/kie/workbench/client/resources/i18n/NavigationConstants.java
@@ -34,8 +34,6 @@ public interface NavigationConstants
 
     NavigationConstants INSTANCE = GWT.create(NavigationConstants.class);
 
-    String navTreeRootName();
-
     String navTreeWorkbenchName();
 
     String navTreeDesignName();
@@ -67,8 +65,6 @@ public interface NavigationConstants
     String navTreeProcessesAndTasksDashboardName();
 
     String navTreeBusinessDashboardsName();
-
-    String navTreeRootDescr();
 
     String navTreeWorkbenchDescr();
 

--- a/kie-wb-parent/kie-wb-monitoring-webapp/src/main/resources/org/kie/workbench/client/resources/i18n/NavigationConstants.properties
+++ b/kie-wb-parent/kie-wb-monitoring-webapp/src/main/resources/org/kie/workbench/client/resources/i18n/NavigationConstants.properties
@@ -1,4 +1,3 @@
-navTreeRootName=Root
 navTreeWorkbenchName=Workbench
 navTreeDesignName=Design
 navTreeDashboardsName=Dashboards
@@ -16,8 +15,7 @@ navTreeTasksListName=Task Lists
 navTreeProcessesAndTasksDashboardName=Process & Task Reports
 navTreeBusinessDashboardsName=Business Dashboards
 
-navTreeRootDescr=The navigation root node
-navTreeWorkbenchDescr=The workbench top menu bar
+navTreeWorkbenchDescr=The navigation tree used to display the workbench''s top menu bar
 navTreeDesignDescr=Design
 navTreeDashboardsDescr=Dashboards
 navTreeDevOpsDescr=DevOps

--- a/kie-wb-parent/kie-wb-monitoring-webapp/src/test/java/org/kie/workbench/client/KieWorkbenchEntryPointTest.java
+++ b/kie-wb-parent/kie-wb-monitoring-webapp/src/test/java/org/kie/workbench/client/KieWorkbenchEntryPointTest.java
@@ -19,8 +19,9 @@ package org.kie.workbench.client;
 import com.google.gwtmockito.GwtMockitoTestRunner;
 import org.dashbuilder.client.cms.screen.explorer.ContentExplorerScreen;
 import org.dashbuilder.client.navigation.NavigationManager;
+import org.dashbuilder.client.navigation.event.NavTreeLoadedEvent;
 import org.dashbuilder.client.navigation.impl.NavigationManagerImpl;
-import org.dashbuilder.client.navigation.widget.NavTreeEditor;
+import org.dashbuilder.client.navigation.widget.editor.NavTreeEditor;
 import org.dashbuilder.navigation.NavGroup;
 import org.dashbuilder.navigation.NavItem;
 import org.dashbuilder.navigation.NavTree;
@@ -40,6 +41,7 @@ import org.uberfire.client.workbench.Workbench;
 import org.uberfire.client.workbench.widgets.menu.megamenu.WorkbenchMegaMenuPresenter;
 import org.uberfire.ext.security.management.client.ClientUserSystemManager;
 import org.uberfire.mocks.CallerMock;
+import org.uberfire.mocks.EventSourceMock;
 import org.uberfire.mvp.Command;
 import org.uberfire.workbench.model.menu.MenuFactory;
 
@@ -89,6 +91,9 @@ public class KieWorkbenchEntryPointTest {
     @Mock
     protected NavTreeEditor navTreeEditor;
 
+    @Mock
+    protected EventSourceMock<NavTreeLoadedEvent> navTreeLoadedEvent;
+
     private KieWorkbenchEntryPoint kieWorkbenchEntryPoint;
 
     @Before
@@ -96,6 +101,7 @@ public class KieWorkbenchEntryPointTest {
         navTreeDefinitions = new NavTreeDefinitions();
         navigationManager = new NavigationManagerImpl(new CallerMock<>(navigationServices),
                                                       null,
+                                                      navTreeLoadedEvent,
                                                       null,
                                                       null);
 

--- a/kie-wb-parent/kie-wb-webapp/src/main/java/org/kie/workbench/client/KieWorkbenchEntryPoint.java
+++ b/kie-wb-parent/kie-wb-webapp/src/main/java/org/kie/workbench/client/KieWorkbenchEntryPoint.java
@@ -22,7 +22,7 @@ import javax.inject.Inject;
 import org.dashbuilder.client.cms.screen.explorer.ContentExplorerScreen;
 import org.dashbuilder.client.navigation.NavigationManager;
 import org.dashbuilder.client.navigation.event.NavTreeChangedEvent;
-import org.dashbuilder.client.navigation.widget.NavTreeEditor;
+import org.dashbuilder.client.navigation.widget.editor.NavTreeEditor;
 import org.dashbuilder.navigation.NavTree;
 import org.guvnor.common.services.shared.config.AppConfigService;
 import org.jboss.errai.common.client.api.Caller;

--- a/kie-wb-parent/kie-wb-webapp/src/main/java/org/kie/workbench/client/navigation/NavTreeDefinitions.java
+++ b/kie-wb-parent/kie-wb-webapp/src/main/java/org/kie/workbench/client/navigation/NavTreeDefinitions.java
@@ -41,7 +41,6 @@ import static org.kie.workbench.common.workbench.client.PerspectiveIds.TASKS_ADM
 @ApplicationScoped
 public class NavTreeDefinitions {
 
-    public static final String GROUP_ROOT = "root";
     public static final String GROUP_WORKBENCH = "wb_group";
 
     public static final String GROUP_DESIGN = "wb_group_design";
@@ -67,17 +66,11 @@ public class NavTreeDefinitions {
     private NavigationConstants i18n = NavigationConstants.INSTANCE;
 
     public NavTree buildDefaultNavTree() {
-        NavTreeBuilder builder = new NavTreeBuilder()
-                .group(GROUP_ROOT,
-                       i18n.navTreeRootName(),
-                       i18n.navTreeRootDescr(),
-                       false)
+        return new NavTreeBuilder()
                 .group(GROUP_WORKBENCH,
-                       i18n.navTreeWorkbenchName(),
-                       i18n.navTreeWorkbenchDescr(),
-                       false);
-
-        return builder
+                        i18n.navTreeWorkbenchName(),
+                        i18n.navTreeWorkbenchDescr(),
+                        false)
                 .group(GROUP_DESIGN,
                        i18n.navTreeDesignName(),
                        i18n.navTreeDesignDescr(),
@@ -157,7 +150,6 @@ public class NavTreeDefinitions {
                       i18n.navTreeBusinessDashboardsDescr(),
                       true,
                       perspective(APPS))
-                .endGroup()
                 .endGroup()
                 .endGroup()
                 .build();

--- a/kie-wb-parent/kie-wb-webapp/src/main/java/org/kie/workbench/client/resources/i18n/NavigationConstants.java
+++ b/kie-wb-parent/kie-wb-webapp/src/main/java/org/kie/workbench/client/resources/i18n/NavigationConstants.java
@@ -34,8 +34,6 @@ public interface NavigationConstants
 
     NavigationConstants INSTANCE = GWT.create(NavigationConstants.class);
 
-    String navTreeRootName();
-
     String navTreeWorkbenchName();
 
     String navTreeHomeName();
@@ -71,8 +69,6 @@ public interface NavigationConstants
     String navTreeProcessesAndTasksDashboardName();
 
     String navTreeBusinessDashboardsName();
-
-    String navTreeRootDescr();
 
     String navTreeWorkbenchDescr();
 

--- a/kie-wb-parent/kie-wb-webapp/src/main/resources/org/kie/workbench/client/resources/i18n/NavigationConstants.properties
+++ b/kie-wb-parent/kie-wb-webapp/src/main/resources/org/kie/workbench/client/resources/i18n/NavigationConstants.properties
@@ -1,4 +1,3 @@
-navTreeRootName=Root
 navTreeWorkbenchName=Workbench
 navTreeHomeName=Home
 navTreeDesignName=Design
@@ -18,8 +17,7 @@ navTreeTasksListName=Task Lists
 navTreeProcessesAndTasksDashboardName=Process & Task Reports
 navTreeBusinessDashboardsName=Business Dashboards
 
-navTreeRootDescr=The navigation root node
-navTreeWorkbenchDescr=The workbench top menu bar
+navTreeWorkbenchDescr=The navigation tree used to display the workbench''s top menu bar
 navTreeHomeDescr=Home page
 navTreeDesignDescr=Design
 navTreeProjectsDescr=Projects

--- a/kie-wb-parent/kie-wb-webapp/src/test/java/org/kie/workbench/client/KieWorkbenchEntryPointTest.java
+++ b/kie-wb-parent/kie-wb-webapp/src/test/java/org/kie/workbench/client/KieWorkbenchEntryPointTest.java
@@ -19,8 +19,11 @@ package org.kie.workbench.client;
 import com.google.gwtmockito.GwtMockitoTestRunner;
 import org.dashbuilder.client.cms.screen.explorer.ContentExplorerScreen;
 import org.dashbuilder.client.navigation.NavigationManager;
+import org.dashbuilder.client.navigation.event.NavTreeLoadedEvent;
 import org.dashbuilder.client.navigation.impl.NavigationManagerImpl;
-import org.dashbuilder.client.navigation.widget.NavTreeEditor;
+import org.dashbuilder.client.navigation.widget.editor.NavTreeEditor;
+import org.dashbuilder.client.navigation.widget.editor.NavTreeEditorView;
+import org.dashbuilder.client.navigation.widget.editor.TargetPerspectiveEditor;
 import org.dashbuilder.navigation.NavGroup;
 import org.dashbuilder.navigation.NavItem;
 import org.dashbuilder.navigation.NavTree;
@@ -42,6 +45,7 @@ import org.uberfire.client.workbench.Workbench;
 import org.uberfire.client.workbench.widgets.menu.megamenu.WorkbenchMegaMenuPresenter;
 import org.uberfire.ext.security.management.client.ClientUserSystemManager;
 import org.uberfire.mocks.CallerMock;
+import org.uberfire.mocks.EventSourceMock;
 import org.uberfire.mvp.Command;
 import org.uberfire.workbench.model.menu.MenuFactory;
 
@@ -97,6 +101,12 @@ public class KieWorkbenchEntryPointTest {
     @Mock
     protected NavTreeEditor navTreeEditor;
 
+    @Mock
+    protected TargetPerspectiveEditor targetPerspectiveEditor;
+
+    @Mock
+    protected EventSourceMock<NavTreeLoadedEvent> navTreeLoadedEvent;
+
     private KieWorkbenchEntryPoint kieWorkbenchEntryPoint;
 
     @Before
@@ -104,6 +114,7 @@ public class KieWorkbenchEntryPointTest {
         navTreeDefinitions = new NavTreeDefinitions();
         navigationManager = new NavigationManagerImpl(new CallerMock<>(navigationServices),
                                                       null,
+                                                      navTreeLoadedEvent,
                                                       null,
                                                       null);
 
@@ -130,7 +141,9 @@ public class KieWorkbenchEntryPointTest {
 
         doNothing().when(kieWorkbenchEntryPoint).hideLoadingPopup();
 
-        navTreeEditor = spy(new NavTreeEditor(mock(NavTreeEditor.View.class), syncBeanManager, perspectiveTreeProvider));
+        navTreeEditor = spy(new NavTreeEditor(mock(NavTreeEditorView.class), null, syncBeanManager, null,
+                perspectiveTreeProvider, targetPerspectiveEditor, null, null, null));
+
         when(contentExplorerScreen.getNavTreeEditor()).thenReturn(navTreeEditor);
     }
 

--- a/kie-wb-tests/kie-wb-tests-gui/src/main/java/org/kie/wb/selenium/model/PrimaryNavbar.java
+++ b/kie-wb-tests/kie-wb-tests-gui/src/main/java/org/kie/wb/selenium/model/PrimaryNavbar.java
@@ -38,7 +38,7 @@ public class PrimaryNavbar {
     private static final Logger LOG = LoggerFactory.getLogger(PrimaryNavbar.class);
     //Contains both the link to expand menu as well as menu item links
     private static final String NAVBAR_MENU = ".navbar li.dropdown:has(a#mega-menu-dropdown)";
-    private static final String INFO_ALERT = "div[class*='alert-info']";
+    private static final String INFO_ALERT = "div.info-alert:not(.uf-cms-nav-alert-panel)";
 
     @FindBy(css = "#mega-menu > nav")
     private WebElement navbar;


### PR DESCRIPTION
The CMS perspective design changes requires to adjust the initialization of the default navigation tree configuration. As the following screenshot shows, only a default nav tree entry is available which corresponds to the workbench's top menu bar configuration:

![navtree](https://user-images.githubusercontent.com/2429839/31458604-e27e64b4-aec0-11e7-9063-63d5f296c3a7.png)

@ederign @kkufova Can you guys review and approve please?

Depends on https://github.com/dashbuilder/dashbuilder/pull/376