### PR TITLE
Remove duplicated dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,13 +90,6 @@
         <scope>import</scope>
       </dependency>
       <dependency>
-        <groupId>org.kie.soup</groupId>
-        <artifactId>kie-soup-bom</artifactId>
-        <version>${version.org.kie}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-      <dependency>
         <groupId>org.kie</groupId>
         <artifactId>kie-bom</artifactId>
         <version>${version.org.kie}</version>


### PR DESCRIPTION
Fixing the following warnings:
```
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for org.kie:kie-wb-theme:pom:7.5.0-SNAPSHOT
[WARNING] 'dependencyManagement.dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: org.kie.soup:kie-soup-bom:pom -> duplicate declaration of version ${version.org.kie} @ org.kie:kie-wb-distributions:[unknown-version], /home/hrk/Devel/github.com/jhrcek/kie-wb-distributions/pom.xml, line 92, column 19
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for org.kie:kie-wb-distributions:pom:7.5.0-SNAPSHOT
[WARNING] 'dependencyManagement.dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: org.kie.soup:kie-soup-bom:pom -> duplicate declaration of version ${version.org.kie} @ org.kie:kie-wb-distributions:[unknown-version], /home/hrk/Devel/github.com/jhrcek/kie-wb-distributions/pom.xml, line 92, column 19
[WARNING] 
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING] 
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING] 
```