### PR TITLE
Remove bogus batik-ext dependency

### DIFF
--- a/kie-drools-wb-parent/kie-drools-wb-webapp/pom.xml
+++ b/kie-drools-wb-parent/kie-drools-wb-webapp/pom.xml
@@ -929,10 +929,6 @@
         </exclusion>
       </exclusions>
     </dependency>
-    <dependency>
-      <groupId>org.apache.xmlgraphics</groupId>
-      <artifactId>batik-ext</artifactId>
-    </dependency>
 
     <!-- org.dashbuilder -->
     <dependency>

--- a/kie-drools-wb-parent/kie-drools-wb-webapp/pom.xml
+++ b/kie-drools-wb-parent/kie-drools-wb-webapp/pom.xml
@@ -112,6 +112,11 @@
     </dependency>
 
     <dependency>
+      <groupId>xml-apis</groupId>
+      <artifactId>xml-apis-ext</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.jboss.resteasy</groupId>
       <artifactId>resteasy-cdi</artifactId>
       <scope>provided</scope>

--- a/kie-wb-parent/kie-wb-webapp/pom.xml
+++ b/kie-wb-parent/kie-wb-webapp/pom.xml
@@ -1018,10 +1018,6 @@
         </exclusion>
       </exclusions>
     </dependency>
-    <dependency>
-      <groupId>org.apache.xmlgraphics</groupId>
-      <artifactId>batik-ext</artifactId>
-    </dependency>
 
     <!-- jBPM Workitems -->
     <dependency>

--- a/kie-wb-parent/kie-wb-webapp/pom.xml
+++ b/kie-wb-parent/kie-wb-webapp/pom.xml
@@ -109,6 +109,11 @@
     </dependency>
 
     <dependency>
+      <groupId>xml-apis</groupId>
+      <artifactId>xml-apis-ext</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.jboss.resteasy</groupId>
       <artifactId>resteasy-cdi</artifactId>
       <scope>provided</scope>


### PR DESCRIPTION
This dependency should not be here. If it is needed it should be
declared by the module that actually needs it (e.g. the
jbpm-designer-backed).