### PR TITLE
Prevent gwtbootstrap3-extras ending up in WARs

### DIFF
--- a/kie-wb-parent/kie-wb-monitoring-webapp/pom.xml
+++ b/kie-wb-parent/kie-wb-monitoring-webapp/pom.xml
@@ -556,6 +556,12 @@
       <artifactId>gwtbootstrap3</artifactId>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>org.gwtbootstrap3</groupId>
+      <artifactId>gwtbootstrap3-extras</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
 
     <dependency>
       <groupId>org.owasp.encoder</groupId>

--- a/kie-wb-parent/kie-wb-webapp/pom.xml
+++ b/kie-wb-parent/kie-wb-webapp/pom.xml
@@ -976,6 +976,11 @@
       <artifactId>gwtbootstrap3</artifactId>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>org.gwtbootstrap3</groupId>
+      <artifactId>gwtbootstrap3-extras</artifactId>
+      <scope>provided</scope>
+    </dependency>    
 
     <dependency>
       <groupId>org.owasp.encoder</groupId>


### PR DESCRIPTION
Before this fix gwtbootstrap3-extras jar ended up in WEB-INF/lib of both kie-wb and kie-wb-monitoring (in kie-drools-wb it's already declared as provided so that war doesn't have this problem).

@cristianonicolai can you please check and merge?