### PR TITLE
Add "sourcemaps" profile to include source maps in kie-wb war

### DIFF
--- a/kie-wb-parent/kie-wb-webapp/pom.xml
+++ b/kie-wb-parent/kie-wb-webapp/pom.xml
@@ -980,7 +980,7 @@
       <groupId>org.gwtbootstrap3</groupId>
       <artifactId>gwtbootstrap3-extras</artifactId>
       <scope>provided</scope>
-    </dependency>    
+    </dependency>
 
     <dependency>
       <groupId>org.owasp.encoder</groupId>
@@ -2401,6 +2401,57 @@
           <scope>provided</scope>
         </dependency>
       </dependencies>
+    </profile>
+
+     <!-- Fast compiled build including Source maps for easier debugging.
+     At the moment only enabled for kie-wb -->
+    <profile>
+      <id>sourcemaps</id>
+      <activation>
+        <property>
+          <name>sourcemaps</name>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>gwt-maven-plugin</artifactId>
+            <configuration>
+              <module>org.kie.workbench.FastCompiledKIEWebappWithSourcemaps</module>
+              <saveSource>true</saveSource>
+            </configuration>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-war-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>add-source-maps</id>
+                <phase>package</phase>
+                <goals>
+                  <goal>war</goal>
+                </goals>
+                <configuration>
+                  <webResources>
+                    <resource>
+                      <directory>${basedir}/target/extra/org.kie.workbench.KIEWebapp/src</directory>
+                      <targetPath>sourcemaps</targetPath>
+                    </resource>
+                    <resource>
+                      <directory>${basedir}/target/extra/org.kie.workbench.KIEWebapp/symbolMaps</directory>
+                      <includes>
+                        <include>*.json</include>
+                      </includes>
+                      <targetPath>sourcemaps</targetPath>
+                    </resource>
+                  </webResources>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
     </profile>
 
   </profiles>

--- a/kie-wb-parent/kie-wb-webapp/src/main/resources/org/kie/workbench/FastCompiledKIEWebappWithSourcemaps.gwt.xml
+++ b/kie-wb-parent/kie-wb-webapp/src/main/resources/org/kie/workbench/FastCompiledKIEWebappWithSourcemaps.gwt.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<module rename-to="org.kie.workbench.KIEWebapp">
+
+    <inherits name="org.kie.workbench.FastCompiledKIEWebapp"/>
+
+    <set-property name="compiler.useSourceMaps" value="true"/>
+    <set-configuration-property name="includeSourceMapUrl"
+	                        value="sourcemaps/__HASH___sourceMap__FRAGMENT__.json"/>
+</module>


### PR DESCRIPTION
I'm trying to enable source map debugging in production compiled kie-wb.war (so far I'm trying to get it directly to kie-wb. Later I'm going to split this into separate profile to be enabled on demand only).

I'm stealing inspiration from Max who enabled it in [errai demo](https://github.com/errai/errai-tutorial/commit/d79aee98fae5c3041617e2e4ba24e056a3490840). 

The first commit in the PR makes gwt compiler source maps in  `./kie-wb-parent/kie-wb-webapp/target/extra/org.kie.workbench.KIEWebapp/...`

I'm struggling with the second step: ensure those sourcemaps are copied to final kie-wb-VERSION-eap7.war @manstis @mbarkley could you please give me a hint how to achieve that? I've no idea which module should have this "copy sourcemaps to war" configuration (also not sure if this should be done by maven-war-plugin or maven-assembly-plugin)? 

The second commit is one of many failed attempts to configure that :(