### PR TITLE
[7.5.x] Add "sourcemap" profile to enable sourcemap debugging of kie-wb war

### DIFF
--- a/kie-wb-parent/kie-wb-webapp/pom.xml
+++ b/kie-wb-parent/kie-wb-webapp/pom.xml
@@ -980,7 +980,7 @@
       <groupId>org.gwtbootstrap3</groupId>
       <artifactId>gwtbootstrap3-extras</artifactId>
       <scope>provided</scope>
-    </dependency>    
+    </dependency>
 
     <dependency>
       <groupId>org.owasp.encoder</groupId>
@@ -2406,6 +2406,57 @@
           <scope>provided</scope>
         </dependency>
       </dependencies>
+    </profile>
+
+     <!-- Fast compiled build including Source maps for easier debugging.
+     At the moment only enabled for kie-wb -->
+    <profile>
+      <id>sourcemaps</id>
+      <activation>
+        <property>
+          <name>sourcemaps</name>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>gwt-maven-plugin</artifactId>
+            <configuration>
+              <module>org.kie.workbench.FastCompiledKIEWebappWithSourcemaps</module>
+              <saveSource>true</saveSource>
+            </configuration>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-war-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>add-source-maps</id>
+                <phase>package</phase>
+                <goals>
+                  <goal>war</goal>
+                </goals>
+                <configuration>
+                  <webResources>
+                    <resource>
+                      <directory>${basedir}/target/extra/org.kie.workbench.KIEWebapp/src</directory>
+                      <targetPath>sourcemaps</targetPath>
+                    </resource>
+                    <resource>
+                      <directory>${basedir}/target/extra/org.kie.workbench.KIEWebapp/symbolMaps</directory>
+                      <includes>
+                        <include>*.json</include>
+                      </includes>
+                      <targetPath>sourcemaps</targetPath>
+                    </resource>
+                  </webResources>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
     </profile>
 
   </profiles>

--- a/kie-wb-parent/kie-wb-webapp/src/main/resources/org/kie/workbench/FastCompiledKIEWebappWithSourcemaps.gwt.xml
+++ b/kie-wb-parent/kie-wb-webapp/src/main/resources/org/kie/workbench/FastCompiledKIEWebappWithSourcemaps.gwt.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<module rename-to="org.kie.workbench.KIEWebapp">
+
+    <inherits name="org.kie.workbench.FastCompiledKIEWebapp"/>
+
+    <set-property name="compiler.useSourceMaps" value="true"/>
+    <set-configuration-property name="includeSourceMapUrl"
+	                        value="sourcemaps/__HASH___sourceMap__FRAGMENT__.json"/>
+</module>


### PR DESCRIPTION
Despite 7.5.x branch being in "blockers only" mode, I'd still like to kindly as for this to be merged,  since this change :
- doesn't affect normal build at all (you need to enable `-Psourcemaps` for it to have any effect)
- would be really helpful for QE's troubleshooting of mysterious UI bugs (that this version abounds in)


