### PR TITLE
Update selenium tests after the merge of project oriented

### DIFF
--- a/kie-wb-tests/kie-wb-tests-gui/src/main/java/org/kie/wb/selenium/model/KieSeleniumTest.java
+++ b/kie-wb-tests/kie-wb-tests-gui/src/main/java/org/kie/wb/selenium/model/KieSeleniumTest.java
@@ -15,41 +15,32 @@
  */
 package org.kie.wb.selenium.model;
 
-import java.util.Optional;
-
 import org.jboss.arquillian.drone.api.annotation.Drone;
 import org.jboss.arquillian.graphene.page.Page;
 import org.jboss.arquillian.junit.Arquillian;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
+import org.kie.wb.selenium.model.persps.HomePerspective;
 import org.kie.wb.selenium.util.ScreenshotOnFailure;
 import org.openqa.selenium.WebDriver;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @RunWith(Arquillian.class)
 public abstract class KieSeleniumTest {
 
-    private static final Logger LOG = LoggerFactory.getLogger(KieSeleniumTest.class);
-
     @Drone
     protected static WebDriver driver;
-
     @Page
     protected LoginPage login;
-
-    public static final KieWbDistribution DISTRO = kieWbDistribution();
-
+    @Page
+    protected HomePerspective home;
     @Rule
     public ScreenshotOnFailure screenshotter = new ScreenshotOnFailure();
+    protected static final KieWbDistribution DISTRO = kieWbDistribution();
 
     private static KieWbDistribution kieWbDistribution() {
         String prop = System.getProperty("app.name");
-        final Optional<KieWbDistribution> kieWbDistribution = KieWbDistribution.fromWarNameString(prop);
-        if (kieWbDistribution.isPresent() == false) {
-            throw new IllegalStateException("Invalid app.name='" + prop + "' Expecting kie-wb, kie-wb-monitoring or kie-drools-wb");
-        }
-        LOG.info("Tested application: {}", prop);
-        return kieWbDistribution.get();
+        return KieWbDistribution
+                .fromWarNameString(prop)
+                .orElseThrow(() -> new IllegalStateException("Invalid app.name='" + prop + "' Expecting kie-wb, kie-wb-monitoring or kie-drools-wb"));
     }
 }

--- a/kie-wb-tests/kie-wb-tests-gui/src/main/java/org/kie/wb/selenium/model/KieWbDistribution.java
+++ b/kie-wb-tests/kie-wb-tests-gui/src/main/java/org/kie/wb/selenium/model/KieWbDistribution.java
@@ -16,23 +16,22 @@
 
 package org.kie.wb.selenium.model;
 
-import java.util.Arrays;
 import java.util.Optional;
+import java.util.stream.Stream;
 
 public enum KieWbDistribution {
 
     KIE_WB,
-
     KIE_DROOLS_WB,
-
     KIE_WB_MONITORING;
 
     public static Optional<KieWbDistribution> fromWarNameString(final String warName) {
-        return Arrays.asList(KieWbDistribution.values()).stream().filter(distro -> distro.getWarName().equals(warName)).findFirst();
+        return Stream.of(KieWbDistribution.values())
+                .filter(distro -> distro.getWarName().equals(warName))
+                .findFirst();
     }
 
     public String getWarName() {
-        return this.name().toLowerCase().replace("_",
-                                                 "-");
+        return this.name().toLowerCase().replace("_", "-");
     }
 }

--- a/kie-wb-tests/kie-wb-tests-gui/src/main/java/org/kie/wb/selenium/model/LoginPage.java
+++ b/kie-wb-tests/kie-wb-tests-gui/src/main/java/org/kie/wb/selenium/model/LoginPage.java
@@ -40,17 +40,16 @@ public class LoginPage extends PageObject {
     @Page
     private HomePerspective home;
 
-    public HomePerspective loginDefaultUser() {
-        return loginAs(KIE_USER, KIE_PASS);
+    public void loginDefaultUser() {
+        loginAs(KIE_USER, KIE_PASS);
     }
 
-    public HomePerspective loginAs(String username, String password) {
+    public void loginAs(String username, String password) {
         submitCredentials(username, password);
         home.waitForLoaded();
-        return home;
     }
 
-    public void getLoginPage(){
+    public void get() {
         driver.get(BASE_URL);
     }
 

--- a/kie-wb-tests/kie-wb-tests-gui/src/main/java/org/kie/wb/selenium/model/PrimaryNavbar.java
+++ b/kie-wb-tests/kie-wb-tests-gui/src/main/java/org/kie/wb/selenium/model/PrimaryNavbar.java
@@ -18,7 +18,6 @@ package org.kie.wb.selenium.model;
 import org.jboss.arquillian.graphene.Graphene;
 import org.kie.wb.selenium.model.persps.AbstractPerspective;
 import org.kie.wb.selenium.model.persps.AdminPagePerspective;
-import org.kie.wb.selenium.model.persps.ProcessAndTaskDashboardPerspective;
 import org.kie.wb.selenium.model.persps.ProjectLibraryPerspective;
 import org.kie.wb.selenium.model.widgets.DropdownMenu;
 import org.kie.wb.selenium.util.BusyPopup;
@@ -31,7 +30,6 @@ import org.slf4j.LoggerFactory;
 
 import static org.kie.wb.selenium.model.KieSeleniumTest.driver;
 import static org.kie.wb.selenium.util.ByUtil.jquery;
-import static org.openqa.selenium.By.cssSelector;
 
 public class PrimaryNavbar {
 
@@ -56,17 +54,13 @@ public class PrimaryNavbar {
         logoutMenu.selectItem("Log Out");
     }
 
-    public ProjectLibraryPerspective projectAuthoring() {
+    public ProjectLibraryPerspective projects() {
         return navigateTo(Persp.PROJECTS);
     }
 
     public AdminPagePerspective admin() {
         adminLink.click();
         return initPerspective(Persp.ADMIN);
-    }
-
-    public ProcessAndTaskDashboardPerspective processAndTaskDashboard() {
-        return navigateTo(Persp.PROCESS_AND_TASK_DASHBOARD);
     }
 
     public <T extends AbstractPerspective> T navigateTo(Persp<T> p) {

--- a/kie-wb-tests/kie-wb-tests-gui/src/main/java/org/kie/wb/selenium/model/persps/ProjectLibraryPerspective.java
+++ b/kie-wb-tests/kie-wb-tests-gui/src/main/java/org/kie/wb/selenium/model/persps/ProjectLibraryPerspective.java
@@ -32,7 +32,6 @@ public class ProjectLibraryPerspective extends AbstractPerspective {
     private static final Logger LOG = LoggerFactory.getLogger(ProjectLibraryPerspective.class);
 
     private static final By
-            WELCOME_MESSAGE = By.id("welcome"),
             TEAM_BREADCRUMB = By.linkText("myteam"),
             PROJECT_ACTIONS_BUTTON = By.id("dropdown-space-actions"),
             IMPORT_PROJECT_BUTTON = By.linkText("Import Project"),
@@ -62,16 +61,15 @@ public class ProjectLibraryPerspective extends AbstractPerspective {
         return ImportProjectsScreen.newInstance();
     }
 
-    public boolean isProjectListEmpty() {
-        return Waits.isElementPresent(WELCOME_MESSAGE);
-    }
-
     public void openProjectList() {
         click(TEAM_BREADCRUMB);
+        // A moment to load projects
+        Waits.pause(2_000);
     }
 
-    public void importDemoProject(String projectName) {
-        click(ByJQuery.selector("button:contains('" + projectName + "')"));
+    public void clickProjectCard(String projectName) {
+        By projectCard = ByJQuery.selector("[data-i18n-prefix='PopulatedLibraryView.'] .card-pf-title:contains('" + projectName + "')");
+        click(projectCard);
     }
 
     public void buildAndDeployProject() {
@@ -81,18 +79,19 @@ public class ProjectLibraryPerspective extends AbstractPerspective {
 
     public void importStockExampleProject(String... projects) {
         ImportProjectsScreen importProjectsScreen = trySamples();
-        importProjectsScreen.selectProjects(projects);
-        importProjectsScreen.ok();
+        importProjectsScreen
+                .selectProjects(projects)
+                .ok();
     }
 
-    public void importCustomExampleProject(Repository repo,
-                                           String... projects) {
+    public void importCustomExampleProject(Repository repo, String... projects) {
         ImportRepositoryModal modal = importProject();
         modal.selectCustomRepository(repo.getUrl());
 
         ImportProjectsScreen importProjectsScreen = modal.importProjects();
-        importProjectsScreen.selectProjects(projects);
-        importProjectsScreen.ok();
+        importProjectsScreen
+                .selectProjects(projects)
+                .ok();
     }
 
     private void possiblyOverrideGavConflict() {

--- a/kie-wb-tests/kie-wb-tests-gui/src/main/java/org/kie/wb/selenium/model/persps/authoring/ImportProjectsScreen.java
+++ b/kie-wb-tests/kie-wb-tests-gui/src/main/java/org/kie/wb/selenium/model/persps/authoring/ImportProjectsScreen.java
@@ -35,17 +35,20 @@ public class ImportProjectsScreen extends PageObject {
     @FindBy(css = "button.btn-primary")
     private WebElement okButton;
 
-    public void selectProjects(String... projects) {
+    public ImportProjectsScreen selectProjects(String... projects) {
         for (String project : projects) {
             By projectCardLocator = jquery(".card-pf-view-select:has(.card-pf-title:contains('%s'))", project);
             WebElement projectCard = Waits.elementPresent(projectCardLocator);
             waitForLoaded();
             projectCard.click();
         }
+        return this;
     }
 
     public void ok() {
         okButton.click();
+        // a moment for imported projects to load
+        Waits.pause(5_000);
     }
 
     public static ImportProjectsScreen newInstance() {

--- a/kie-wb-tests/kie-wb-tests-gui/src/main/java/org/kie/wb/selenium/util/ScreenshotOnFailure.java
+++ b/kie-wb-tests/kie-wb-tests-gui/src/main/java/org/kie/wb/selenium/util/ScreenshotOnFailure.java
@@ -23,6 +23,8 @@ import org.junit.rules.TestWatcher;
 import org.junit.runner.Description;
 import org.openqa.selenium.OutputType;
 import org.openqa.selenium.TakesScreenshot;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static org.kie.wb.selenium.util.GrapheneUtil.getDriver;
 
@@ -32,6 +34,7 @@ import static org.kie.wb.selenium.util.GrapheneUtil.getDriver;
  */
 public class ScreenshotOnFailure extends TestWatcher {
 
+    private static final Logger LOG = LoggerFactory.getLogger(ScreenshotOnFailure.class);
     private final File screenshotDir = initScreenshotDir();
 
     @Override
@@ -48,9 +51,9 @@ public class ScreenshotOnFailure extends TestWatcher {
         File targetScreenshot = new File(screenshotDir, filename + ".png");
         try {
             FileUtils.copyFile(tmpScreenshot, targetScreenshot);
-            System.out.println("Screenshot on failure taken: " + targetScreenshot);
+            LOG.info("Screenshot on failure taken: {}", targetScreenshot);
         } catch (IOException ex) {
-            System.err.print("Failed to take a screenshot on failed test " + filename + " " + ex.getMessage());
+            LOG.info("Failed to take a screenshot on failed test {} : {}", filename, ex.getMessage());
         }
     }
 
@@ -59,9 +62,9 @@ public class ScreenshotOnFailure extends TestWatcher {
         File targetFile = new File(screenshotDir, filename + ".html");
         try {
             FileUtils.writeStringToFile(targetFile, pageSource, "UTF-8");
-            System.out.println("Saved page HTML source on failure: " + targetFile);
+            LOG.info("Saved page HTML source on failure: {}", targetFile);
         } catch (IOException ex) {
-            System.err.println("Failed to save page HTML source " + ex.getMessage());
+            LOG.info("Failed to save page HTML source ", ex);
         }
     }
 
@@ -69,7 +72,7 @@ public class ScreenshotOnFailure extends TestWatcher {
         String dir = System.getProperty("selenium.screenshots.dir");
         if (dir == null) {
             throw new IllegalStateException("Property selenium.screenshots.dir "
-                    + "(where screenshot taken by WebDriver will be put) must be defined: " + dir);
+                                                    + "(where screenshot taken by WebDriver will be put) must be defined: " + dir);
         }
         File scd = new File(dir);
         if (!scd.exists()) {

--- a/kie-wb-tests/kie-wb-tests-gui/src/main/java/org/kie/wb/selenium/util/ScreenshotOnFailure.java
+++ b/kie-wb-tests/kie-wb-tests-gui/src/main/java/org/kie/wb/selenium/util/ScreenshotOnFailure.java
@@ -71,8 +71,8 @@ public class ScreenshotOnFailure extends TestWatcher {
     private File initScreenshotDir() {
         String dir = System.getProperty("selenium.screenshots.dir");
         if (dir == null) {
-            throw new IllegalStateException("Property selenium.screenshots.dir "
-                                                    + "(where screenshot taken by WebDriver will be put) must be defined: " + dir);
+            throw new IllegalStateException(
+                    "Property selenium.screenshots.dir (where screenshot taken by WebDriver will be put) was null");
         }
         File scd = new File(dir);
         if (!scd.exists()) {

--- a/kie-wb-tests/kie-wb-tests-gui/src/main/java/org/kie/wb/selenium/util/Waits.java
+++ b/kie-wb-tests/kie-wb-tests-gui/src/main/java/org/kie/wb/selenium/util/Waits.java
@@ -61,9 +61,7 @@ public class Waits {
         try {
             elementPresent(locator, timeoutSeconds);
             return true;
-        } catch (NoSuchElementException nse) {
-            return false;
-        } catch(TimeoutException toe) {
+        } catch (NoSuchElementException | TimeoutException nse) {
             return false;
         }
     }

--- a/kie-wb-tests/kie-wb-tests-gui/src/test/java/org/kie/wb/selenium/ui/LoadAllPerspectivesIntegrationTest.java
+++ b/kie-wb-tests/kie-wb-tests-gui/src/test/java/org/kie/wb/selenium/ui/LoadAllPerspectivesIntegrationTest.java
@@ -19,8 +19,6 @@ import org.junit.Test;
 import org.kie.wb.selenium.model.KieSeleniumTest;
 import org.kie.wb.selenium.model.Persp;
 import org.kie.wb.selenium.model.persps.AbstractPerspective;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import static org.junit.Assert.assertTrue;
 
@@ -29,17 +27,13 @@ import static org.junit.Assert.assertTrue;
  */
 public class LoadAllPerspectivesIntegrationTest extends KieSeleniumTest {
 
-    private static final Logger LOG = LoggerFactory.getLogger(LoadAllPerspectivesIntegrationTest.class);
-
     @Test
     public void allPerspectivesCanBeLoaded() {
         login.get();
         login.loginDefaultUser();
 
         for (Persp<?> p : Persp.getAllPerspectives(DISTRO)) {
-            LOG.info("Checking perspective '" + p.getName() + "..");
             AbstractPerspective perspective = home.getNavbar().navigateTo(p);
-            LOG.info("Navigated to perspective '" + p.getName() + "..");
             assertTrue("Perspective " + p.getName() + " should be loaded",
                        perspective.isDisplayed());
         }

--- a/kie-wb-tests/kie-wb-tests-gui/src/test/java/org/kie/wb/selenium/ui/LoadAllPerspectivesIntegrationTest.java
+++ b/kie-wb-tests/kie-wb-tests-gui/src/test/java/org/kie/wb/selenium/ui/LoadAllPerspectivesIntegrationTest.java
@@ -19,11 +19,10 @@ import org.junit.Test;
 import org.kie.wb.selenium.model.KieSeleniumTest;
 import org.kie.wb.selenium.model.Persp;
 import org.kie.wb.selenium.model.persps.AbstractPerspective;
-import org.kie.wb.selenium.model.persps.HomePerspective;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Login and verify each perspective can be navigated to and loads some content.
@@ -34,8 +33,8 @@ public class LoadAllPerspectivesIntegrationTest extends KieSeleniumTest {
 
     @Test
     public void allPerspectivesCanBeLoaded() {
-        login.getLoginPage();
-        HomePerspective home = login.loginDefaultUser();
+        login.get();
+        login.loginDefaultUser();
 
         for (Persp<?> p : Persp.getAllPerspectives(DISTRO)) {
             LOG.info("Checking perspective '" + p.getName() + "..");

--- a/kie-wb-tests/kie-wb-tests-gui/src/test/java/org/kie/wb/selenium/ui/LoginIntegrationTest.java
+++ b/kie-wb-tests/kie-wb-tests-gui/src/test/java/org/kie/wb/selenium/ui/LoginIntegrationTest.java
@@ -17,16 +17,15 @@ package org.kie.wb.selenium.ui;
 
 import org.junit.Test;
 import org.kie.wb.selenium.model.KieSeleniumTest;
-import org.kie.wb.selenium.model.persps.HomePerspective;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertTrue;
 
 public class LoginIntegrationTest extends KieSeleniumTest {
 
     @Test
     public void loginAndLogout() {
-        login.getLoginPage();
-        HomePerspective home = login.loginDefaultUser();
+        login.get();
+        login.loginDefaultUser();
         assertTrue(home.isDisplayed());
 
         home.logout();

--- a/kie-wb-tests/kie-wb-tests-gui/src/test/java/org/kie/wb/selenium/ui/ProjectLibraryIntegrationTest.java
+++ b/kie-wb-tests/kie-wb-tests-gui/src/test/java/org/kie/wb/selenium/ui/ProjectLibraryIntegrationTest.java
@@ -67,17 +67,10 @@ public class ProjectLibraryIntegrationTest extends KieSeleniumTest {
 
     private void importBuildDeployAndCheckArtifact(String projectName, String projectGav, Runnable stepsToImportProject) {
         stepsToImportProject.run();
-        workaroundOpenProjectAfterImport(projectName);
         deployAndCheckArtifact(projectGav);
         // Important: don't put logout in @After, because ScreenshotOnFailure captures screenshots after @After,
         // which results in useless image of login screen
         home.logout();
-    }
-
-    // Workaround - after selecting examples to import and clicking OK, library stays in the list of projects - is this a bug?
-    private void workaroundOpenProjectAfterImport(String projectName) {
-        projectLibrary.openProjectList();
-        projectLibrary.clickProjectCard(projectName);
     }
 
     private void deployAndCheckArtifact(String artifact) {

--- a/kie-wb-tests/kie-wb-tests-gui/src/test/java/org/kie/wb/selenium/ui/StandalonePerspectivesIntegrationTest.java
+++ b/kie-wb-tests/kie-wb-tests-gui/src/test/java/org/kie/wb/selenium/ui/StandalonePerspectivesIntegrationTest.java
@@ -15,23 +15,18 @@
  */
 package org.kie.wb.selenium.ui;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import org.assertj.core.api.Assertions;
 import org.jboss.arquillian.graphene.findby.ByJQuery;
-import org.jboss.arquillian.graphene.page.Page;
 import org.junit.Before;
 import org.junit.Test;
 import org.kie.wb.selenium.model.KieSeleniumTest;
-import org.kie.wb.selenium.model.persps.HomePerspective;
 import org.kie.wb.selenium.util.Waits;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriverException;
 
-public class StandalonePerspectivesIntegrationTest extends KieSeleniumTest {
+import static org.assertj.core.api.Assertions.assertThat;
 
-    @Page
-    private HomePerspective home;
+public class StandalonePerspectivesIntegrationTest extends KieSeleniumTest {
 
     private final static String
             BASE_URL = System.getProperty("kie.wb.url"),
@@ -42,14 +37,14 @@ public class StandalonePerspectivesIntegrationTest extends KieSeleniumTest {
             COMPLETE_URL = BASE_URL + "/" + APP_CONTEXT + STANDALONE_PARAMETER + PERSPECTIVE_ID;
 
     private static final By
-            ELEMENT = ByJQuery.selector("h3:contains('Project Explorer')"),
-            HEADER = By.id("workbenchHeaderPanel");
+            EXPLORER_HEADER = ByJQuery.selector("h3:contains('Project Explorer')"),
+            WORKBENCH_HEADER = By.id("workbenchHeaderPanel");
 
     @Before
     public void setUp() {
-        login.getLoginPage();
+        login.get();
         if (login.isDisplayed()) {
-            home = login.loginDefaultUser();
+            login.loginDefaultUser();
         }
     }
 
@@ -69,7 +64,7 @@ public class StandalonePerspectivesIntegrationTest extends KieSeleniumTest {
 
     private void verifyPerspectiveIsLoaded() {
         try {
-            Waits.elementPresent(ELEMENT, 10);
+            Waits.elementPresent(EXPLORER_HEADER, 10);
         } catch (WebDriverException exception) {
             Assertions.fail("The standalone perspective could not be loaded.", exception);
         }
@@ -77,7 +72,7 @@ public class StandalonePerspectivesIntegrationTest extends KieSeleniumTest {
 
     private void verifyPresenceOfHeader(boolean headerIncluded) {
         int
-                actualHeaderCount = driver.findElements(HEADER).size(),
+                actualHeaderCount = driver.findElements(WORKBENCH_HEADER).size(),
                 expectedHeaderCount = headerIncluded ? 1 : 0;
 
         String headerAssertionMessage = String.format("There should %s be AppNavBar on the page.", headerIncluded ? "" : "NOT");


### PR DESCRIPTION
@paulovmr ProjectLibraryIntegrationTest is failing now on master after project oriented has been merged. The root cause is the change in behaviour in Project Import screen:
- previously after selecting projects in import screen and clicking OK the app automatically moved to Project List.
- current behaviour (seems broken): after clicking OK, the app stays in the list of projects to import. Is this reported/should I report it?

Also fixed the issue with screenshot on failure showing login screen (we must not put logout into `@After` methods) and did a general code cleanup in selenium module.

@manstis @karreiro FYI this is the fix of selenium tests as promised yesterday. Let me retest this few times to confirm stability..