### PR TITLE
[7.5.x] DROOLS-2314 : Standalone decision central is not branded

### DIFF
--- a/kie-drools-wb-parent/kie-drools-wb-distribution-wars/pom.xml
+++ b/kie-drools-wb-parent/kie-drools-wb-distribution-wars/pom.xml
@@ -221,7 +221,7 @@
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-security-management-tomcat</artifactId>
     </dependency>
-    
+
     <!-- for tomcat and RestEasy -->
     <dependency>
       <groupId>org.scannotation</groupId>
@@ -264,6 +264,23 @@
       <groupId>org.kie</groupId>
       <artifactId>kie-drools-wb-webapp</artifactId>
       <type>war</type>
+    </dependency>
+
+    <dependency>
+      <groupId>org.kie</groupId>
+      <artifactId>kie-drools-wb-webapp</artifactId>
+      <type>jar</type>
+      <classifier>swarm</classifier>
+      <exclusions>
+        <exclusion>
+          <groupId>org.yaml</groupId>
+          <artifactId>snakeyaml</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>xml-apis</groupId>
+          <artifactId>xml-apis-ext</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
   </dependencies>
 
@@ -323,8 +340,12 @@
               <descriptors>
                 <descriptor>${project.basedir}/src/main/productized/assembly-kie-drools-wb-eap-7-redhat.xml</descriptor>
                 <descriptor>${project.basedir}/src/main/productized/assembly-kie-drools-wb-tomcat-8-redhat.xml</descriptor>
+                <descriptor>${project.basedir}/src/main/productized/assembly-kie-drools-wb-swarm-redhat.xml</descriptor>
               </descriptors>
               <archive>
+                <manifest>
+                  <mainClass>org.wildfly.swarm.bootstrap.Main</mainClass>
+                </manifest>
                 <addMavenDescriptor>false</addMavenDescriptor>
               </archive>
             </configuration>

--- a/kie-drools-wb-parent/kie-drools-wb-distribution-wars/src/main/assembly/component-kie-drools-wb-swarm-common.xml
+++ b/kie-drools-wb-parent/kie-drools-wb-distribution-wars/src/main/assembly/component-kie-drools-wb-swarm-common.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2018 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~       http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<component xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/component/1.1.3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/component/1.1.3 http://maven.apache.org/xsd/component-1.1.3.xsd">
+  <!-- Assembly configuration for WildFly 10 and EAP 7, shared between the community and product assemblies. -->
+  <dependencySets>
+    <dependencySet>
+      <includes>
+        <include>org.kie:${artifactId}-webapp:jar:swarm</include>
+      </includes>
+      <outputDirectory>.</outputDirectory>
+      <unpack>true</unpack>
+      <unpackOptions>
+        <excludes>
+          <exclude>_bootstrap/${artifactId}-webapp.war</exclude>
+        </excludes>
+      </unpackOptions>
+      <useStrictFiltering>true</useStrictFiltering>
+    </dependencySet>
+  </dependencySets>
+
+  <files>
+
+    <file>
+      <source>${project.basedir}/target/kie-drools-wb-${version.org.kie}-eap7-redhat.war</source>
+      <outputDirectory>_bootstrap</outputDirectory>
+      <destName>kie-drools-wb-webapp.war</destName>
+    </file>
+  </files>
+</component>

--- a/kie-drools-wb-parent/kie-drools-wb-distribution-wars/src/main/productized/assembly-kie-drools-wb-swarm-redhat.xml
+++ b/kie-drools-wb-parent/kie-drools-wb-distribution-wars/src/main/productized/assembly-kie-drools-wb-swarm-redhat.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2018 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~       http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+
+  <!-- including a . in the id will modify the *classifier* of the artifact, instead of the name/id of the artifact -->
+  <id>swarm-redhat</id>
+  <formats>
+    <format>jar</format>
+    <format>dir</format>
+  </formats>
+
+  <includeBaseDirectory>false</includeBaseDirectory>
+
+  <componentDescriptors>
+    <componentDescriptor>src/main/assembly/component-kie-drools-wb-swarm-common.xml</componentDescriptor>
+  </componentDescriptors>
+
+</assembly>

--- a/kie-wb-parent/kie-wb-distribution-wars/kie-wb/pom.xml
+++ b/kie-wb-parent/kie-wb-distribution-wars/kie-wb/pom.xml
@@ -21,6 +21,23 @@
       <artifactId>kie-wb-webapp</artifactId>
       <type>war</type>
     </dependency>
+
+    <dependency>
+      <groupId>org.kie</groupId>
+      <artifactId>kie-wb-webapp</artifactId>
+      <type>jar</type>
+      <classifier>swarm</classifier>
+      <exclusions>
+        <exclusion>
+          <groupId>org.yaml</groupId>
+          <artifactId>snakeyaml</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>xml-apis</groupId>
+          <artifactId>xml-apis-ext</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
   </dependencies>
 
   <profiles>
@@ -81,7 +98,13 @@
                   <descriptors>
                     <descriptor>${project.parent.basedir}/src/main/productized/assembly-kie-wb-eap-7-redhat.xml</descriptor>
                     <descriptor>${project.parent.basedir}/src/main/productized/assembly-kie-wb-tomcat-8-redhat.xml</descriptor>
+                    <descriptor>${project.parent.basedir}/src/main/productized/assembly-kie-wb-swarm-redhat.xml</descriptor>
                   </descriptors>
+                  <archive>
+                    <manifest>
+                      <mainClass>org.wildfly.swarm.bootstrap.Main</mainClass>
+                    </manifest>
+                  </archive>
                 </configuration>
               </execution>
             </executions>

--- a/kie-wb-parent/kie-wb-distribution-wars/src/main/assembly/component-kie-wb-swarm-common.xml
+++ b/kie-wb-parent/kie-wb-distribution-wars/src/main/assembly/component-kie-wb-swarm-common.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2018 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~       http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<component xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/component/1.1.3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/component/1.1.3 http://maven.apache.org/xsd/component-1.1.3.xsd">
+  <!-- Assembly configuration for WildFly 10 and EAP 7, shared between the community and product assemblies. -->
+  <dependencySets>
+    <dependencySet>
+      <includes>
+        <include>org.kie:${artifactId}-webapp:jar:swarm</include>
+      </includes>
+      <outputDirectory>.</outputDirectory>
+      <unpack>true</unpack>
+      <unpackOptions>
+        <excludes>
+          <exclude>_bootstrap/${artifactId}-webapp.war</exclude>
+        </excludes>
+      </unpackOptions>
+      <useStrictFiltering>true</useStrictFiltering>
+    </dependencySet>
+  </dependencySets>
+
+  <files>
+
+    <file>
+      <source>${project.basedir}/target/kie-wb-${version.org.kie}-eap7-redhat.war</source>
+      <outputDirectory>_bootstrap</outputDirectory>
+      <destName>kie-wb-webapp.war</destName>
+    </file>
+  </files>
+</component>

--- a/kie-wb-parent/kie-wb-distribution-wars/src/main/productized/assembly-kie-wb-swarm-redhat.xml
+++ b/kie-wb-parent/kie-wb-distribution-wars/src/main/productized/assembly-kie-wb-swarm-redhat.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2018 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~       http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+
+  <!-- including a . in the id will modify the *classifier* of the artifact, instead of the name/id of the artifact -->
+  <id>swarm-redhat</id>
+  <formats>
+    <format>jar</format>
+    <format>dir</format>
+  </formats>
+
+  <includeBaseDirectory>false</includeBaseDirectory>
+
+  <componentDescriptors>
+    <componentDescriptor>${project.parent.basedir}/src/main/assembly/component-kie-wb-swarm-common.xml</componentDescriptor>
+  </componentDescriptors>
+
+</assembly>


### PR DESCRIPTION
(cherry picked from commit dd1a811ee6a2e87cf6f91a3d190afd32d9c9921c)

https://issues.jboss.org/browse/RHDM-344

https://issues.jboss.org/browse/DROOLS-2314
Bundle:
https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/708
https://github.com/kiegroup/kie-wb-distributions/pull/689