### PR TITLE
Stabilize community Selenium tests.

### DIFF
--- a/kie-wb-tests/kie-wb-tests-gui/src/main/java/org/kie/wb/selenium/model/Persp.java
+++ b/kie-wb-tests/kie-wb-tests-gui/src/main/java/org/kie/wb/selenium/model/Persp.java
@@ -92,7 +92,7 @@ public class Persp<T extends AbstractPerspective> {
 
     public static final Persp<TasksPerspective> TASKS
             = new Persp<>("Track",
-                          "Task Lists",
+                          "Task Inbox",
                           TasksPerspective.class,
                           KIE_WB,
                           KIE_WB_MONITORING);

--- a/kie-wb-tests/kie-wb-tests-gui/src/test/java/org/kie/wb/selenium/ui/ProjectLibraryIntegrationTest.java
+++ b/kie-wb-tests/kie-wb-tests-gui/src/test/java/org/kie/wb/selenium/ui/ProjectLibraryIntegrationTest.java
@@ -42,7 +42,7 @@ public class ProjectLibraryIntegrationTest extends KieSeleniumTest {
     @Test
     public void importAndBuildProjectFromStockRepository() {
         final String
-                projectName = "optacloud",
+                projectName = "OptaCloud",
                 projectGav = "optacloud:optacloud:1.0.0-SNAPSHOT";
 
         importBuildDeployAndCheckArtifact(


### PR DESCRIPTION
This PR is related to this one: https://github.com/kiegroup/kie-wb-playground/pull/49 (_Make example project names consistent._) These two PRs should be merged together to prevent the community Selenium tests from failing.

@jhrcek, @manstis, could you please review?