### PR TITLE
JBPM-5649: Removed dependency to Stunner's default backend services.

### DIFF
--- a/kie-drools-wb-parent/kie-drools-wb-webapp/pom.xml
+++ b/kie-drools-wb-parent/kie-drools-wb-webapp/pom.xml
@@ -1619,12 +1619,6 @@
 
     <dependency>
       <groupId>org.kie.workbench.stunner</groupId>
-      <artifactId>kie-wb-common-stunner-backend</artifactId>
-      <scope>runtime</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.kie.workbench.stunner</groupId>
       <artifactId>kie-wb-common-stunner-client-common</artifactId>
       <scope>provided</scope>
     </dependency>

--- a/kie-wb-parent/kie-wb-webapp/pom.xml
+++ b/kie-wb-parent/kie-wb-webapp/pom.xml
@@ -1852,12 +1852,6 @@
 
     <dependency>
       <groupId>org.kie.workbench.stunner</groupId>
-      <artifactId>kie-wb-common-stunner-backend</artifactId>
-      <scope>runtime</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.kie.workbench.stunner</groupId>
       <artifactId>kie-wb-common-stunner-client-common</artifactId>
       <scope>provided</scope>
     </dependency>


### PR DESCRIPTION
Hey @hasys @jomarko 

This removes the use on the workbench of some unused services from Stunner.

It **depends on**
https://github.com/kiegroup/kie-wb-common/pull/1509
https://github.com/kiegroup/jbpm-wb/pull/996

Thanks!