### PR TITLE
[7.5.x] Disable Pages perspective in kie-drools-wb tests

### DIFF
--- a/kie-wb-tests/kie-wb-tests-gui/src/main/java/org/kie/wb/selenium/model/Persp.java
+++ b/kie-wb-tests/kie-wb-tests-gui/src/main/java/org/kie/wb/selenium/model/Persp.java
@@ -20,9 +20,25 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import org.kie.wb.selenium.model.persps.*;
+import org.kie.wb.selenium.model.persps.AbstractPerspective;
+import org.kie.wb.selenium.model.persps.AdminPagePerspective;
+import org.kie.wb.selenium.model.persps.ArtifactRepositoryPerspective;
+import org.kie.wb.selenium.model.persps.ContentManagerPerspective;
+import org.kie.wb.selenium.model.persps.ExecutionErrorsPerspective;
+import org.kie.wb.selenium.model.persps.ExecutionServersPerspective;
+import org.kie.wb.selenium.model.persps.HomePerspective;
+import org.kie.wb.selenium.model.persps.JobsPerspective;
+import org.kie.wb.selenium.model.persps.ProcessAndTaskDashboardPerspective;
+import org.kie.wb.selenium.model.persps.ProcessDefinitionsPerspective;
+import org.kie.wb.selenium.model.persps.ProcessInstancesPerspective;
+import org.kie.wb.selenium.model.persps.ProjectLibraryPerspective;
+import org.kie.wb.selenium.model.persps.ProvisioningManagementPerspective;
+import org.kie.wb.selenium.model.persps.TaskAdministrationPerspective;
+import org.kie.wb.selenium.model.persps.TasksPerspective;
 
-import static org.kie.wb.selenium.model.KieWbDistribution.*;
+import static org.kie.wb.selenium.model.KieWbDistribution.KIE_DROOLS_WB;
+import static org.kie.wb.selenium.model.KieWbDistribution.KIE_WB;
+import static org.kie.wb.selenium.model.KieWbDistribution.KIE_WB_MONITORING;
 
 public class Persp<T extends AbstractPerspective> {
 
@@ -48,7 +64,8 @@ public class Persp<T extends AbstractPerspective> {
     public static final Persp<ContentManagerPerspective> PAGES
             = new Persp<>("Design",
                           "Pages",
-                          ContentManagerPerspective.class);
+                          ContentManagerPerspective.class,
+                          KIE_WB);
 
     public static final Persp<ProvisioningManagementPerspective> DEPLOYMENTS
             = new Persp<>("Deploy",


### PR DESCRIPTION
This perspective has been disabled in kie-drools-wb in 7.5.x
in 663add1d1a903845b08af6d7fae21d82dae533b3
because it was not stable - so this commit removes it from UI tests as well.

@mbiarnes FYI this should fix the failing [failing UI test](https://kie-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/view/kieAllBuild-7.5.x/job/kieWbTestsMatrix-kieAllBuild-7.5.x/lastCompletedBuild/testReport/) (not the others).