### PR TITLE
Fix selenium tests

### DIFF
--- a/kie-wb-tests/kie-wb-tests-gui/README.md
+++ b/kie-wb-tests/kie-wb-tests-gui/README.md
@@ -1,25 +1,25 @@
 # KIE Workbench tests
 
-This module contains GUI tests which require KIE Workbench to be running in order to be executed.
+This module contains selenium GUI tests.
 
 ## Running and debugging tests locally
 
 You can run tests directly from the command line.
-Cargo will take care of starting the container and the tests will be run afterwards.
+Cargo will take care of starting the container with kie workbench deployed and the tests will be run afterwards.
 
 ```
-mvn clean verify -Pkie-wb,wildfly10
+mvn clean verify -Pkie-wb,wildfly11
 ```
 
 **Note, Selenium 2.53.0 requires Firefox 46 and is incompatible with later versions.**
 
-Older versions can be downloaded from https://ftp.mozilla.org/pub/firefox/releases/46.0/ and tests ran as below:
+Older versions can be downloaded from https://ftp.mozilla.org/pub/firefox/releases/46.0/ and tests executed as below:
 
 ```
-mvn clean verify -Pkie-wb,wildfly10 -Dwebdriver.firefox.bin=/path/to/older/firefox/<firefox-bin>
+mvn clean verify -Pkie-wb,wildfly11 -Dwebdriver.firefox.bin=/path/to/older/firefox/firefox-bin
 ```
 
 For example:
 ```
-mvn clean verify -Pkie-wb,wildfly10 -Dwebdriver.firefox.bin=/home/myuser/installs/ff46.0/firefox/firefox
+mvn clean verify -Pkie-wb,wildfly11 -Dwebdriver.firefox.bin=/home/myuser/installs/ff46.0/firefox/firefox
 ```

--- a/kie-wb-tests/kie-wb-tests-gui/src/main/java/org/kie/wb/selenium/model/Persp.java
+++ b/kie-wb-tests/kie-wb-tests-gui/src/main/java/org/kie/wb/selenium/model/Persp.java
@@ -20,9 +20,26 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import org.kie.wb.selenium.model.persps.*;
+import org.kie.wb.selenium.model.persps.AbstractPerspective;
+import org.kie.wb.selenium.model.persps.AdminPagePerspective;
+import org.kie.wb.selenium.model.persps.ArtifactRepositoryPerspective;
+import org.kie.wb.selenium.model.persps.ContentManagerPerspective;
+import org.kie.wb.selenium.model.persps.ExecutionErrorsPerspective;
+import org.kie.wb.selenium.model.persps.ExecutionServersPerspective;
+import org.kie.wb.selenium.model.persps.HomePerspective;
+import org.kie.wb.selenium.model.persps.JobsPerspective;
+import org.kie.wb.selenium.model.persps.ProcessDashboardPerspective;
+import org.kie.wb.selenium.model.persps.ProcessDefinitionsPerspective;
+import org.kie.wb.selenium.model.persps.ProcessInstancesPerspective;
+import org.kie.wb.selenium.model.persps.ProjectLibraryPerspective;
+import org.kie.wb.selenium.model.persps.ProvisioningManagementPerspective;
+import org.kie.wb.selenium.model.persps.TaskDashboardPerspective;
+import org.kie.wb.selenium.model.persps.TasksPerspective;
+import org.kie.wb.selenium.model.persps.TaskAdminPerspective;
 
-import static org.kie.wb.selenium.model.KieWbDistribution.*;
+import static org.kie.wb.selenium.model.KieWbDistribution.KIE_DROOLS_WB;
+import static org.kie.wb.selenium.model.KieWbDistribution.KIE_WB;
+import static org.kie.wb.selenium.model.KieWbDistribution.KIE_WB_MONITORING;
 
 public class Persp<T extends AbstractPerspective> {
 
@@ -30,10 +47,12 @@ public class Persp<T extends AbstractPerspective> {
             = new Persp<>("N/A",
                           "Home",
                           HomePerspective.class);
+
     public static final Persp<AdminPagePerspective> ADMIN
             = new Persp<>("N/A",
                           "Admin",
                           AdminPagePerspective.class);
+
     public static final Persp<ArtifactRepositoryPerspective> ARTIFACTS
             = new Persp<>("N/A",
                           "Artifacts",
@@ -54,6 +73,7 @@ public class Persp<T extends AbstractPerspective> {
             = new Persp<>("Deploy",
                           "Deployments",
                           ProvisioningManagementPerspective.class);
+
     public static final Persp<ExecutionServersPerspective> EXECUTION_SERVERS
             = new Persp<>("Deploy",
                           "Execution Servers",
@@ -71,18 +91,21 @@ public class Persp<T extends AbstractPerspective> {
                           ProcessInstancesPerspective.class,
                           KIE_WB,
                           KIE_WB_MONITORING);
-    public static final Persp<TaskAdministrationPerspective> TASK_ADMINISTRATION
+
+    public static final Persp<TaskAdminPerspective> TASKS
             = new Persp<>("Manage",
                           "Tasks",
-                          TaskAdministrationPerspective.class,
+                          TaskAdminPerspective.class,
                           KIE_WB,
                           KIE_WB_MONITORING);
+
     public static final Persp<JobsPerspective> JOBS
             = new Persp<>("Manage",
                           "Jobs",
                           JobsPerspective.class,
                           KIE_WB,
                           KIE_WB_MONITORING);
+
     public static final Persp<ExecutionErrorsPerspective> EXECUTION_ERRORS
             = new Persp<>("Manage",
                           "Execution Errors",
@@ -90,19 +113,21 @@ public class Persp<T extends AbstractPerspective> {
                           KIE_WB,
                           KIE_WB_MONITORING);
 
-    public static final Persp<TasksPerspective> TASKS
+    public static final Persp<TasksPerspective> TASK_INBOX
             = new Persp<>("Track",
                           "Task Inbox",
                           TasksPerspective.class,
                           KIE_WB,
                           KIE_WB_MONITORING);
-    public static final Persp<ProcessDashboardPerspective> PROCESS_DASHBOARD
+
+    public static final Persp<ProcessDashboardPerspective> PROCESS_REPORTS
             = new Persp<>("Track",
                           "Process Reports",
                           ProcessDashboardPerspective.class,
                           KIE_WB,
                           KIE_WB_MONITORING);
-    public static final Persp<TaskDashboardPerspective> TASK_DASHBOARD
+
+    public static final Persp<TaskDashboardPerspective> TASK_REPORTS
             = new Persp<>("Track",
                           "Task Reports",
                           TaskDashboardPerspective.class,
@@ -118,12 +143,12 @@ public class Persp<T extends AbstractPerspective> {
             EXECUTION_SERVERS,
             PROCESS_DEFINITIONS,
             PROCESS_INSTANCES,
-            TASK_ADMINISTRATION,
+            TASKS,
             JOBS,
             EXECUTION_ERRORS,
-            TASKS,
-            PROCESS_DASHBOARD,
-            TASK_DASHBOARD
+            TASK_INBOX,
+            PROCESS_REPORTS,
+            TASK_REPORTS
     ));
     private final String parentMenu;
     private final String menuItem;

--- a/kie-wb-tests/kie-wb-tests-gui/src/main/java/org/kie/wb/selenium/model/persps/ExecutionErrorsPerspective.java
+++ b/kie-wb-tests/kie-wb-tests-gui/src/main/java/org/kie/wb/selenium/model/persps/ExecutionErrorsPerspective.java
@@ -15,15 +15,17 @@
  */
 package org.kie.wb.selenium.model.persps;
 
+import org.jboss.arquillian.graphene.findby.ByJQuery;
 import org.kie.wb.selenium.util.Waits;
 import org.openqa.selenium.By;
 
 public class ExecutionErrorsPerspective extends AbstractPerspective {
 
-    private static final By ACKNOWLEDGED_TAB = By.linkText("Acknowledged");
+    private static final By EXECUTION_ERRORS_BREADCRUMB =
+            ByJQuery.selector("[data-field='breadcrumb']:contains('Manage Execution Errors')");
 
     @Override
     public boolean isDisplayed() {
-        return Waits.isElementPresent(ACKNOWLEDGED_TAB);
+        return Waits.isElementPresent(EXECUTION_ERRORS_BREADCRUMB);
     }
 }

--- a/kie-wb-tests/kie-wb-tests-gui/src/main/java/org/kie/wb/selenium/model/persps/JobsPerspective.java
+++ b/kie-wb-tests/kie-wb-tests-gui/src/main/java/org/kie/wb/selenium/model/persps/JobsPerspective.java
@@ -15,15 +15,17 @@
  */
 package org.kie.wb.selenium.model.persps;
 
+import org.jboss.arquillian.graphene.findby.ByJQuery;
 import org.kie.wb.selenium.util.Waits;
 import org.openqa.selenium.By;
 
 public class JobsPerspective extends AbstractPerspective {
 
-    private static final By ID_COLUMN_HEADER = By.xpath("//th[contains(text(), 'Id')]");
+    private static final By MANAGE_JOBS_BREADCRUMB =
+            ByJQuery.selector("[data-field='breadcrumb']:contains('Manage Jobs')");
 
     @Override
     public boolean isDisplayed() {
-        return Waits.isElementPresent(ID_COLUMN_HEADER);
+        return Waits.isElementPresent(MANAGE_JOBS_BREADCRUMB);
     }
 }

--- a/kie-wb-tests/kie-wb-tests-gui/src/main/java/org/kie/wb/selenium/model/persps/ProcessDashboardPerspective.java
+++ b/kie-wb-tests/kie-wb-tests-gui/src/main/java/org/kie/wb/selenium/model/persps/ProcessDashboardPerspective.java
@@ -15,23 +15,27 @@
  */
 package org.kie.wb.selenium.model.persps;
 
+import org.jboss.arquillian.graphene.findby.ByJQuery;
+import org.jboss.arquillian.graphene.page.Page;
 import org.kie.wb.selenium.util.BusyPopup;
 import org.kie.wb.selenium.util.Waits;
 import org.openqa.selenium.By;
-import org.openqa.selenium.support.PageFactory;
 
 public class ProcessDashboardPerspective extends AbstractPerspective {
 
-    private static final By PROCESSES_TITLE = By.cssSelector("span[title='Process Reports']");
+    private static final By PROCESS_REPORTS_BREADCRUMB =
+            ByJQuery.selector("[data-field='breadcrumb']:contains('Process Reports')");
+
+    @Page
+    private BusyPopup loadingIndicator;
 
     @Override
     public boolean isDisplayed() {
-        return Waits.isElementPresent(PROCESSES_TITLE);
+        return Waits.isElementPresent(PROCESS_REPORTS_BREADCRUMB);
     }
 
     @Override
     public void waitForLoaded() {
-        BusyPopup indicator = PageFactory.initElements(driver, BusyPopup.class);
-        indicator.waitForDisappearance();
+        loadingIndicator.waitForDisappearance();
     }
 }

--- a/kie-wb-tests/kie-wb-tests-gui/src/main/java/org/kie/wb/selenium/model/persps/ProcessDefinitionsPerspective.java
+++ b/kie-wb-tests/kie-wb-tests-gui/src/main/java/org/kie/wb/selenium/model/persps/ProcessDefinitionsPerspective.java
@@ -15,15 +15,17 @@
  */
 package org.kie.wb.selenium.model.persps;
 
+import org.jboss.arquillian.graphene.findby.ByJQuery;
 import org.kie.wb.selenium.util.Waits;
 import org.openqa.selenium.By;
 
 public class ProcessDefinitionsPerspective extends AbstractPerspective {
 
-    private static final By PROC_DEFS_TITLE = By.cssSelector("span[title='Process Definitions']");
+    private static final By PROCESS_DEFINITIONS_BREADCRUMB =
+            ByJQuery.selector("[data-field='breadcrumb']:contains('Manage Process Definitions')");
 
     @Override
     public boolean isDisplayed() {
-        return Waits.isElementPresent(PROC_DEFS_TITLE);
+        return Waits.isElementPresent(PROCESS_DEFINITIONS_BREADCRUMB);
     }
 }

--- a/kie-wb-tests/kie-wb-tests-gui/src/main/java/org/kie/wb/selenium/model/persps/ProcessInstancesPerspective.java
+++ b/kie-wb-tests/kie-wb-tests-gui/src/main/java/org/kie/wb/selenium/model/persps/ProcessInstancesPerspective.java
@@ -15,6 +15,7 @@
  */
 package org.kie.wb.selenium.model.persps;
 
+import org.jboss.arquillian.graphene.findby.ByJQuery;
 import org.jboss.arquillian.graphene.page.Page;
 import org.kie.wb.selenium.util.BusyPopup;
 import org.kie.wb.selenium.util.Waits;
@@ -22,14 +23,15 @@ import org.openqa.selenium.By;
 
 public class ProcessInstancesPerspective extends AbstractPerspective {
 
-    private static final By PROC_INST_TITLE = By.cssSelector("span[title='Process Instances']");
+    private static final By PROCESS_INSTANCES_BREADCRUMB =
+            ByJQuery.selector("[data-field='breadcrumb']:contains('Manage Process Instances')");
 
     @Page
     private BusyPopup busyPopup;
 
     @Override
     public boolean isDisplayed() {
-        return Waits.isElementPresent(PROC_INST_TITLE);
+        return Waits.isElementPresent(PROCESS_INSTANCES_BREADCRUMB);
     }
 
     @Override

--- a/kie-wb-tests/kie-wb-tests-gui/src/main/java/org/kie/wb/selenium/model/persps/TaskAdminPerspective.java
+++ b/kie-wb-tests/kie-wb-tests-gui/src/main/java/org/kie/wb/selenium/model/persps/TaskAdminPerspective.java
@@ -15,15 +15,17 @@
  */
 package org.kie.wb.selenium.model.persps;
 
+import org.jboss.arquillian.graphene.findby.ByJQuery;
 import org.kie.wb.selenium.util.Waits;
 import org.openqa.selenium.By;
 
-public class TaskAdministrationPerspective extends AbstractPerspective {
+public class TaskAdminPerspective extends AbstractPerspective {
 
-    private static final By PERSPECTIVE_TITLE = By.cssSelector("span[title='Tasks']");
+    private static final By MANAGE_TASKS_BREADCRUMB =
+            ByJQuery.selector("[data-field='breadcrumb']:contains('Manage Tasks')");
 
     @Override
     public boolean isDisplayed() {
-        return Waits.isElementPresent(PERSPECTIVE_TITLE);
+        return Waits.isElementPresent(MANAGE_TASKS_BREADCRUMB);
     }
 }

--- a/kie-wb-tests/kie-wb-tests-gui/src/main/java/org/kie/wb/selenium/model/persps/TaskDashboardPerspective.java
+++ b/kie-wb-tests/kie-wb-tests-gui/src/main/java/org/kie/wb/selenium/model/persps/TaskDashboardPerspective.java
@@ -15,23 +15,27 @@
  */
 package org.kie.wb.selenium.model.persps;
 
+import org.jboss.arquillian.graphene.findby.ByJQuery;
+import org.jboss.arquillian.graphene.page.Page;
 import org.kie.wb.selenium.util.BusyPopup;
 import org.kie.wb.selenium.util.Waits;
 import org.openqa.selenium.By;
-import org.openqa.selenium.support.PageFactory;
 
 public class TaskDashboardPerspective extends AbstractPerspective {
 
-    private static final By TASK_TITLE = By.cssSelector("span[title='Task Reports']");
+    private static final By TASK_REPORTS_BREADCRUMB =
+            ByJQuery.selector("[data-field='breadcrumb']:contains('Task Reports')");
+
+    @Page
+    private BusyPopup loadingIndicator;
 
     @Override
     public boolean isDisplayed() {
-        return Waits.isElementPresent(TASK_TITLE);
+        return Waits.isElementPresent(TASK_REPORTS_BREADCRUMB);
     }
 
     @Override
     public void waitForLoaded() {
-        BusyPopup indicator = PageFactory.initElements(driver, BusyPopup.class);
-        indicator.waitForDisappearance();
+        loadingIndicator.waitForDisappearance();
     }
 }

--- a/kie-wb-tests/kie-wb-tests-gui/src/main/java/org/kie/wb/selenium/model/persps/TasksPerspective.java
+++ b/kie-wb-tests/kie-wb-tests-gui/src/main/java/org/kie/wb/selenium/model/persps/TasksPerspective.java
@@ -15,6 +15,7 @@
  */
 package org.kie.wb.selenium.model.persps;
 
+import org.jboss.arquillian.graphene.findby.ByJQuery;
 import org.jboss.arquillian.graphene.page.Page;
 import org.kie.wb.selenium.util.BusyPopup;
 import org.kie.wb.selenium.util.Waits;
@@ -22,13 +23,14 @@ import org.openqa.selenium.By;
 
 public class TasksPerspective extends AbstractPerspective {
 
-    private static final By ACTIVE_FILTER_TITLE = By.xpath("//h4[contains(text(),'Filter Active')]");
+    private static final By TASK_INBOX_BREADCRUMB =
+            ByJQuery.selector("[data-field='breadcrumb']:contains('Task Inbox')");
     @Page
     private BusyPopup loadingIndicator;
 
     @Override
     public boolean isDisplayed() {
-        return Waits.isElementPresent(ACTIVE_FILTER_TITLE);
+        return Waits.isElementPresent(TASK_INBOX_BREADCRUMB);
     }
 
     @Override

--- a/kie-wb-tests/kie-wb-tests-gui/src/test/java/org/kie/wb/selenium/ui/ProjectLibraryIntegrationTest.java
+++ b/kie-wb-tests/kie-wb-tests-gui/src/test/java/org/kie/wb/selenium/ui/ProjectLibraryIntegrationTest.java
@@ -16,6 +16,7 @@
 package org.kie.wb.selenium.ui;
 
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.kie.wb.selenium.model.KieSeleniumTest;
 import org.kie.wb.selenium.model.persps.ArtifactRepositoryPerspective;
@@ -53,6 +54,7 @@ public class ProjectLibraryIntegrationTest extends KieSeleniumTest {
     }
 
     @Test
+    @Ignore("RHBA-581 - [Project Oriented] Impossible to delete 'broken projects'")
     public void importAndBuildProjectFromCustomRepository() {
         final String
                 projectName = "Evaluation",

--- a/kie-wb-tests/kie-wb-tests-gui/src/test/java/org/kie/wb/selenium/ui/StandalonePerspectivesIntegrationTest.java
+++ b/kie-wb-tests/kie-wb-tests-gui/src/test/java/org/kie/wb/selenium/ui/StandalonePerspectivesIntegrationTest.java
@@ -18,6 +18,7 @@ package org.kie.wb.selenium.ui;
 import org.assertj.core.api.Assertions;
 import org.jboss.arquillian.graphene.findby.ByJQuery;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.kie.wb.selenium.model.KieSeleniumTest;
 import org.kie.wb.selenium.util.Waits;
@@ -26,6 +27,7 @@ import org.openqa.selenium.WebDriverException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+@Ignore("RHBA-503 - Standalone perspectives are broken")
 public class StandalonePerspectivesIntegrationTest extends KieSeleniumTest {
 
     private final static String


### PR DESCRIPTION
@manstis Fixing broken selenium tests

1. Recent [jbpm-wb changes](https://github.com/kiegroup/jbpm-wb/pull/994) broke `LoadAllPerspectivesIntegrationTest` - updating locators to reflect those changes (@cristianonicolai FYI)

2. `StandalonePerspectivesIntegrationTest` now started failing because of  [RHBA-503](https://issues.jboss.org/browse/RHBA-503) - added `@Ignore` annotation until it's fixed

3. `ProjectLibraryIntegrationTest#importAndBuildProjectFromCustomRepository` is broken because of [RHBA-581](https://issues.jboss.org/browse/RHBA-581) - added `@Ignore` annotation until it's fixed
