### PR TITLE
[RHBPMS-1622] Set property for very short Errai marshaller class name…

### DIFF
--- a/kie-drools-wb-parent/kie-drools-wb-webapp/pom.xml
+++ b/kie-drools-wb-parent/kie-drools-wb-webapp/pom.xml
@@ -1801,7 +1801,7 @@
           <configuration>
             <deploy>${project.build.directory}/gwt-symbols-deploy</deploy>
             <localWorkers>${gwt.compiler.localWorkers}</localWorkers>
-            <extraJvmArgs>${gwt.memory.settings} -XX:CompileThreshold=7000 -Derrai.jboss.home=${errai.jboss.home} -Derrai.server.classOutput=${project.build.outputDirectory} -Derrai.dynamic_validation.enabled=true -Dorg.kie.demo=true -Dorg.kie.clean.onstartup=true -Dorg.jbpm.designer.perspective=ruleflow -Djava.util.prefs.syncInterval=2000000 -Dorg.uberfire.async.executor.safemode=true</extraJvmArgs>
+            <extraJvmArgs>${gwt.memory.settings} -XX:CompileThreshold=7000 -Derrai.jboss.home=${errai.jboss.home} -Derrai.server.classOutput=${project.build.outputDirectory} -Derrai.dynamic_validation.enabled=true -Dorg.kie.demo=true -Dorg.kie.clean.onstartup=true -Dorg.jbpm.designer.perspective=ruleflow -Djava.util.prefs.syncInterval=2000000 -Dorg.uberfire.async.executor.safemode=true -Derrai.marshalling.very_short_names=${errai.marshalling.very_short_names}</extraJvmArgs>
             <draftCompile>true</draftCompile>
             <module>org.kie.workbench.drools.FastCompiledKIEDroolsWebapp</module>
             <logLevel>INFO</logLevel>

--- a/kie-wb-parent/pom.xml
+++ b/kie-wb-parent/pom.xml
@@ -65,7 +65,7 @@
           <configuration>
             <deploy>${project.build.directory}/gwt-symbols-deploy</deploy>
             <localWorkers>${gwt.compiler.localWorkers}</localWorkers>
-            <extraJvmArgs>${gwt.memory.settings} -XX:CompileThreshold=7000 -Derrai.jboss.home=${errai.jboss.home} -Derrai.server.classOutput=${project.build.outputDirectory} -Derrai.dynamic_validation.enabled=true -Dorg.kie.demo=true -Dorg.kie.clean.onstartup=true -Dorg.uberfire.nio.git.ssh.enabled=false -Djava.util.prefs.syncInterval=2000000 -Dorg.uberfire.async.executor.safemode=true</extraJvmArgs>
+            <extraJvmArgs>${gwt.memory.settings} -XX:CompileThreshold=7000 -Derrai.jboss.home=${errai.jboss.home} -Derrai.server.classOutput=${project.build.outputDirectory} -Derrai.dynamic_validation.enabled=true -Dorg.kie.demo=true -Dorg.kie.clean.onstartup=true -Dorg.uberfire.nio.git.ssh.enabled=false -Djava.util.prefs.syncInterval=2000000 -Dorg.uberfire.async.executor.safemode=true -Derrai.marshalling.very_short_names=${errai.marshalling.very_short_names}</extraJvmArgs>
             <draftCompile>true</draftCompile>
             <module>org.kie.workbench.FastCompiledKIEWebapp</module>
             <logLevel>INFO</logLevel>

--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,7 @@
 
   <properties>
     <findbugs.failOnViolation>true</findbugs.failOnViolation>
+    <errai.marshalling.very_short_names>false</errai.marshalling.very_short_names>
   </properties>
 
   <repositories>
@@ -187,5 +188,21 @@
 
     </plugins>
   </build>
+
+  <profiles>
+
+    <profile>
+      <id>productizedProfile</id>
+      <activation>
+        <property>
+          <name>productized</name>
+        </property>
+      </activation>
+      <properties>
+        <errai.marshalling.very_short_names>true</errai.marshalling.very_short_names>
+      </properties>
+    </profile>
+
+  </profiles>
 
 </project>


### PR DESCRIPTION
…s. (#434) (#733)

Please note that the same fix is tested and merged in 7.7.x,  The errai marshaller class name is short, looks like:
WEB-INF/classes/org/jboss/errai/ServerMarshallingFactoryImpl$MOtd$y_.class
7.7.x https://github.com/kiegroup/kie-wb-distributions/pull/733

Now request to merge it into the master branch.
