### PR TITLE
Add sleepForSecond to the waitUntilJobFinished because of RHPAM-863

### DIFF
--- a/kie-wb-tests/kie-wb-tests-rest/src/main/java/org/kie/wb/test/rest/client/RestWorkbenchClient.java
+++ b/kie-wb-tests/kie-wb-tests-rest/src/main/java/org/kie/wb/test/rest/client/RestWorkbenchClient.java
@@ -309,7 +309,9 @@ public class RestWorkbenchClient implements WorkbenchClient {
         }
 
         JobResult jobResult;
-        int totalSecondsWaited = 0;
+        // added becasue of RHPAM-863
+        sleepForSecond();
+        int totalSecondsWaited = 1;
         while ((jobResult = getJob(request.getJobId())).getStatus() != JobStatus.SUCCESS && seconds-- > 0) {
             switch (jobResult.getStatus()) {
                 case ACCEPTED:


### PR DESCRIPTION
Add sleep for a while to avoid random failing tests.