### PR TITLE
Make jBPM server Distribution for community only

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,6 @@
     <module>kie-wb-tests</module>
     <module>kie-wb-webapp-common</module>
     <module>kie-wb-deployment-validation</module>
-    <module>kie-server-distributions</module>
   </modules>
 
   <dependencyManagement>
@@ -191,6 +190,18 @@
   </build>
 
   <profiles>
+
+    <profile>
+      <id>notProductizedProfile</id>
+      <activation>
+        <property>
+          <name>!productized</name>
+        </property>
+      </activation>
+      <modules>
+        <module>kie-server-distributions</module>
+      </modules>
+    </profile>
 
     <profile>
       <id>productizedProfile</id>


### PR DESCRIPTION
This is for fixing the productizedProfile build error. the org.kie.kie-wb wildfly11 war doesn't exist for productized Profile.
