### PR TITLE
[master] AF-1226: Improve error handling displaying additional info to the GenericErrorPopup

### DIFF
--- a/kie-drools-wb-parent/kie-drools-wb-webapp/src/main/java/org/kie/workbench/drools/client/KieDroolsWorkbenchEntryPoint.java
+++ b/kie-drools-wb-parent/kie-drools-wb-webapp/src/main/java/org/kie/workbench/drools/client/KieDroolsWorkbenchEntryPoint.java
@@ -30,6 +30,7 @@ import org.jboss.errai.ioc.client.api.EntryPoint;
 import org.kie.workbench.common.workbench.client.admin.DefaultAdminPageHelper;
 import org.kie.workbench.common.workbench.client.authz.PermissionTreeSetup;
 import org.kie.workbench.common.workbench.client.entrypoint.DefaultWorkbenchEntryPoint;
+import org.kie.workbench.common.workbench.client.error.DefaultWorkbenchErrorCallback;
 import org.kie.workbench.common.workbench.client.menu.DefaultWorkbenchFeaturesMenusHelper;
 import org.kie.workbench.drools.client.navigation.NavTreeDefinitions;
 import org.uberfire.client.authz.PerspectiveTreeProvider;
@@ -77,9 +78,11 @@ public class KieDroolsWorkbenchEntryPoint extends DefaultWorkbenchEntryPoint {
                                         final DefaultAdminPageHelper adminPageHelper,
                                         final NavTreeDefinitions navTreeDefinitions,
                                         final NavigationManager navigationManager,
-                                        final NavigationExplorerScreen navigationExplorerScreen) {
+                                        final NavigationExplorerScreen navigationExplorerScreen,
+                                        final DefaultWorkbenchErrorCallback defaultWorkbenchErrorCallback) {
         super(appConfigService,
-              activityBeansCache);
+              activityBeansCache,
+              defaultWorkbenchErrorCallback);
         this.menusHelper = menusHelper;
         this.userSystemManager = userSystemManager;
         this.menuBar = menuBar;

--- a/kie-drools-wb-parent/kie-drools-wb-webapp/src/test/java/org/kie/workbench/drools/client/KieDroolsWorkbenchEntryPointTest.java
+++ b/kie-drools-wb-parent/kie-drools-wb-webapp/src/test/java/org/kie/workbench/drools/client/KieDroolsWorkbenchEntryPointTest.java
@@ -37,6 +37,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.workbench.client.admin.DefaultAdminPageHelper;
 import org.kie.workbench.common.workbench.client.authz.PermissionTreeSetup;
+import org.kie.workbench.common.workbench.client.error.DefaultWorkbenchErrorCallback;
 import org.kie.workbench.common.workbench.client.menu.DefaultWorkbenchFeaturesMenusHelper;
 import org.kie.workbench.drools.client.navigation.NavTreeDefinitions;
 import org.kie.workbench.drools.client.resources.i18n.NavigationConstants;
@@ -109,6 +110,9 @@ public class KieDroolsWorkbenchEntryPointTest {
     @Mock
     protected EventSourceMock<NavTreeLoadedEvent> navTreeLoadedEvent;
 
+    @Mock
+    private DefaultWorkbenchErrorCallback defaultWorkbenchErrorCallback;
+
     private KieDroolsWorkbenchEntryPoint kieWorkbenchEntryPoint;
 
     @Before
@@ -137,7 +141,8 @@ public class KieDroolsWorkbenchEntryPointTest {
                                                                       adminPageHelper,
                                                                       navTreeDefinitions,
                                                                       navigationManager,
-                                                                      navigationExplorerScreen));
+                                                                      navigationExplorerScreen,
+                                                                      defaultWorkbenchErrorCallback));
 
         doNothing().when(kieWorkbenchEntryPoint).hideLoadingPopup();
 

--- a/kie-wb-parent/kie-wb-monitoring-webapp/src/main/java/org/kie/workbench/client/KieWorkbenchEntryPoint.java
+++ b/kie-wb-parent/kie-wb-monitoring-webapp/src/main/java/org/kie/workbench/client/KieWorkbenchEntryPoint.java
@@ -30,6 +30,7 @@ import org.kie.workbench.client.navigation.NavTreeDefinitions;
 import org.kie.workbench.common.workbench.client.admin.DefaultAdminPageHelper;
 import org.kie.workbench.common.workbench.client.authz.PermissionTreeSetup;
 import org.kie.workbench.common.workbench.client.entrypoint.DefaultWorkbenchEntryPoint;
+import org.kie.workbench.common.workbench.client.error.DefaultWorkbenchErrorCallback;
 import org.kie.workbench.common.workbench.client.menu.DefaultWorkbenchFeaturesMenusHelper;
 import org.uberfire.client.mvp.ActivityBeansCache;
 import org.uberfire.client.workbench.Workbench;
@@ -74,9 +75,11 @@ public class KieWorkbenchEntryPoint extends DefaultWorkbenchEntryPoint {
                                   final DefaultAdminPageHelper adminPageHelper,
                                   final NavTreeDefinitions navTreeDefinitions,
                                   final NavigationManager navigationManager,
-                                  final NavigationExplorerScreen navigationExplorerScreen) {
+                                  final NavigationExplorerScreen navigationExplorerScreen,
+                                  final DefaultWorkbenchErrorCallback defaultWorkbenchErrorCallback) {
         super(appConfigService,
-              activityBeansCache);
+              activityBeansCache,
+              defaultWorkbenchErrorCallback);
         this.menusHelper = menusHelper;
         this.userSystemManager = userSystemManager;
         this.menuBar = menuBar;

--- a/kie-wb-parent/kie-wb-monitoring-webapp/src/test/java/org/kie/workbench/client/KieWorkbenchEntryPointTest.java
+++ b/kie-wb-parent/kie-wb-monitoring-webapp/src/test/java/org/kie/workbench/client/KieWorkbenchEntryPointTest.java
@@ -34,6 +34,7 @@ import org.kie.workbench.client.navigation.NavTreeDefinitions;
 import org.kie.workbench.client.resources.i18n.NavigationConstants;
 import org.kie.workbench.common.workbench.client.admin.DefaultAdminPageHelper;
 import org.kie.workbench.common.workbench.client.authz.PermissionTreeSetup;
+import org.kie.workbench.common.workbench.client.error.DefaultWorkbenchErrorCallback;
 import org.kie.workbench.common.workbench.client.menu.DefaultWorkbenchFeaturesMenusHelper;
 import org.mockito.Mock;
 import org.uberfire.client.mvp.ActivityBeansCache;
@@ -94,6 +95,9 @@ public class KieWorkbenchEntryPointTest {
     @Mock
     protected EventSourceMock<NavTreeLoadedEvent> navTreeLoadedEvent;
 
+    @Mock
+    private DefaultWorkbenchErrorCallback defaultWorkbenchErrorCallback;
+
     private KieWorkbenchEntryPoint kieWorkbenchEntryPoint;
 
     @Before
@@ -124,7 +128,8 @@ public class KieWorkbenchEntryPointTest {
                                                                 adminPageHelper,
                                                                 navTreeDefinitions,
                                                                 navigationManager,
-                navigationExplorerScreen));
+                                                                navigationExplorerScreen,
+                                                                defaultWorkbenchErrorCallback));
 
         doNothing().when(kieWorkbenchEntryPoint).hideLoadingPopup();
         when(navigationExplorerScreen.getNavTreeEditor()).thenReturn(navTreeEditor);

--- a/kie-wb-parent/kie-wb-webapp/src/main/java/org/kie/workbench/client/KieWorkbenchEntryPoint.java
+++ b/kie-wb-parent/kie-wb-webapp/src/main/java/org/kie/workbench/client/KieWorkbenchEntryPoint.java
@@ -31,6 +31,7 @@ import org.kie.workbench.client.navigation.NavTreeDefinitions;
 import org.kie.workbench.common.workbench.client.admin.DefaultAdminPageHelper;
 import org.kie.workbench.common.workbench.client.authz.PermissionTreeSetup;
 import org.kie.workbench.common.workbench.client.entrypoint.DefaultWorkbenchEntryPoint;
+import org.kie.workbench.common.workbench.client.error.DefaultWorkbenchErrorCallback;
 import org.kie.workbench.common.workbench.client.menu.DefaultWorkbenchFeaturesMenusHelper;
 import org.uberfire.client.mvp.ActivityBeansCache;
 import org.uberfire.client.workbench.Workbench;
@@ -75,9 +76,11 @@ public class KieWorkbenchEntryPoint extends DefaultWorkbenchEntryPoint {
                                   final DefaultAdminPageHelper adminPageHelper,
                                   final NavTreeDefinitions navTreeDefinitions,
                                   final NavigationManager navigationManager,
-                                  final NavigationExplorerScreen navigationExplorerScreen) {
+                                  final NavigationExplorerScreen navigationExplorerScreen,
+                                  final DefaultWorkbenchErrorCallback defaultWorkbenchErrorCallback) {
         super(appConfigService,
-              activityBeansCache);
+              activityBeansCache,
+              defaultWorkbenchErrorCallback);
         this.menusHelper = menusHelper;
         this.userSystemManager = userSystemManager;
         this.menuBar = menuBar;

--- a/kie-wb-parent/kie-wb-webapp/src/test/java/org/kie/workbench/client/KieWorkbenchEntryPointTest.java
+++ b/kie-wb-parent/kie-wb-webapp/src/test/java/org/kie/workbench/client/KieWorkbenchEntryPointTest.java
@@ -39,6 +39,7 @@ import org.kie.workbench.client.navigation.NavTreeDefinitions;
 import org.kie.workbench.client.resources.i18n.NavigationConstants;
 import org.kie.workbench.common.workbench.client.admin.DefaultAdminPageHelper;
 import org.kie.workbench.common.workbench.client.authz.PermissionTreeSetup;
+import org.kie.workbench.common.workbench.client.error.DefaultWorkbenchErrorCallback;
 import org.kie.workbench.common.workbench.client.menu.DefaultWorkbenchFeaturesMenusHelper;
 import org.mockito.Mock;
 import org.uberfire.client.authz.PerspectiveTreeProvider;
@@ -119,6 +120,9 @@ public class KieWorkbenchEntryPointTest {
     @Mock
     protected EventSourceMock<NavTreeLoadedEvent> navTreeLoadedEvent;
 
+    @Mock
+    private DefaultWorkbenchErrorCallback defaultWorkbenchErrorCallback;
+
     private KieWorkbenchEntryPoint kieWorkbenchEntryPoint;
 
     @Before
@@ -149,7 +153,8 @@ public class KieWorkbenchEntryPointTest {
                                                                 adminPageHelper,
                                                                 navTreeDefinitions,
                                                                 navigationManager,
-                                                                navigationExplorerScreen));
+                                                                navigationExplorerScreen,
+                                                                defaultWorkbenchErrorCallback));
 
         doNothing().when(kieWorkbenchEntryPoint).hideLoadingPopup();
 


### PR DESCRIPTION
This is already merged in 7.7.x. Cherry-picking to master.

Related:
https://github.com/errai/errai/pull/352
https://github.com/kiegroup/appformer/pull/412
https://github.com/kiegroup/kie-wb-common/pull/1951
https://github.com/kiegroup/drools-wb/pull/883
https://github.com/kiegroup/jbpm-wb/pull/1169
https://github.com/kiegroup/optaplanner-wb/pull/290
https://github.com/kiegroup/kie-wb-distributions/pull/776
