### PR TITLE
Troubleshoot flaky cleanup in workbench rest tests

### DIFF
--- a/kie-wb-tests/kie-wb-tests-rest/src/main/java/org/kie/wb/test/rest/client/ClientRequestTimedOutException.java
+++ b/kie-wb-tests/kie-wb-tests-rest/src/main/java/org/kie/wb/test/rest/client/ClientRequestTimedOutException.java
@@ -1,0 +1,20 @@
+package org.kie.wb.test.rest.client;
+
+import org.guvnor.rest.client.JobResult;
+
+/**
+ * Special case of {@link NotSuccessException} to be used in cases when failure was caused by client request timing out.
+ */
+public class ClientRequestTimedOutException extends NotSuccessException {
+
+    private final int timeout;
+
+    public ClientRequestTimedOutException(JobResult jobResult, int timeout) {
+        super(jobResult);
+        this.timeout = timeout;
+    }
+
+    public int getTimeout() {
+        return timeout;
+    }
+}

--- a/kie-wb-tests/kie-wb-tests-rest/src/main/java/org/kie/wb/test/rest/client/RestWorkbenchClient.java
+++ b/kie-wb-tests/kie-wb-tests-rest/src/main/java/org/kie/wb/test/rest/client/RestWorkbenchClient.java
@@ -48,7 +48,7 @@ public class RestWorkbenchClient implements WorkbenchClient {
 
     private static final Logger log = LoggerFactory.getLogger(RestWorkbenchClient.class);
 
-    private static final int DEFAULT_JOB_TIMEOUT_SECONDS = 10;
+    private static final int DEFAULT_JOB_TIMEOUT_SECONDS = 60; // TODO lower this back to 10s after https://issues.jboss.org/browse/AF-1310 is fixed
     private static final int DEFAULT_PROJECT_JOB_TIMEOUT_SECONDS = 60;
     private static final int DEFAULT_CLONE_REPO_TIMEOUT_SECONDS = 60;
     private final int jobTimeoutSeconds;
@@ -322,13 +322,13 @@ public class RestWorkbenchClient implements WorkbenchClient {
                     return request;
                 default:
                     log.warn("  Timeout waiting {} seconds for job to succeed", totalSecondsWaited);
-                    throw new NotSuccessException(jobResult);
+                    throw new ClientRequestTimedOutException(jobResult, totalSecondsWaited);
             }
         }
 
         if (jobResult.getStatus() != JobStatus.SUCCESS) {
             log.warn("  Timeout waiting {} seconds for job to succeed", totalSecondsWaited);
-            throw new NotSuccessException(jobResult);
+            throw new ClientRequestTimedOutException(jobResult, totalSecondsWaited);
         }
 
         return request;

--- a/kie-wb-tests/kie-wb-tests-rest/src/test/java/org/kie/wb/test/rest/functional/JobIntegrationTest.java
+++ b/kie-wb-tests/kie-wb-tests-rest/src/test/java/org/kie/wb/test/rest/functional/JobIntegrationTest.java
@@ -22,22 +22,19 @@ import org.guvnor.rest.client.JobRequest;
 import org.guvnor.rest.client.JobResult;
 import org.guvnor.rest.client.JobStatus;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.kie.wb.test.rest.RestTestBase;
 import org.kie.wb.test.rest.client.RestWorkbenchClient;
 import org.kie.wb.test.rest.client.WorkbenchClient;
 
-@Ignore("See https://issues.jboss.org/browse/DROOLS-2803")
 public class JobIntegrationTest extends RestTestBase {
 
     private static final String SPACE_NAME = "jobTestSpace";
 
-    protected static WorkbenchClient asyncClient;
+    private static WorkbenchClient asyncClient;
 
     @BeforeClass
     public static void setUp() {
-        deleteAllProject();
         deleteAllSpaces();
 
         createSpace(SPACE_NAME);

--- a/kie-wb-tests/kie-wb-tests-rest/src/test/java/org/kie/wb/test/rest/functional/ProjectIntegrationTest.java
+++ b/kie-wb-tests/kie-wb-tests-rest/src/test/java/org/kie/wb/test/rest/functional/ProjectIntegrationTest.java
@@ -32,7 +32,6 @@ import org.guvnor.rest.client.JobStatus;
 import org.guvnor.rest.client.ProjectResponse;
 import org.guvnor.rest.client.TestProjectRequest;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.kie.wb.test.rest.RestTestBase;
 import org.kie.wb.test.rest.client.NotSuccessException;
@@ -40,7 +39,6 @@ import qa.tools.ikeeper.annotation.Jira;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@Ignore("See https://issues.jboss.org/browse/DROOLS-2803")
 public class ProjectIntegrationTest extends RestTestBase {
 
     private static final String SPACE = "projectTestSpace";

--- a/kie-wb-tests/kie-wb-tests-rest/src/test/java/org/kie/wb/test/rest/functional/SpaceIntegrationTest.java
+++ b/kie-wb-tests/kie-wb-tests-rest/src/test/java/org/kie/wb/test/rest/functional/SpaceIntegrationTest.java
@@ -27,13 +27,10 @@ import org.guvnor.rest.client.JobStatus;
 import org.guvnor.rest.client.ProjectResponse;
 import org.guvnor.rest.client.Space;
 import org.guvnor.rest.client.SpaceRequest;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.kie.wb.test.rest.RestTestBase;
 import org.kie.wb.test.rest.client.NotSuccessException;
 import qa.tools.ikeeper.annotation.Jira;
-
-import static org.kie.wb.test.rest.functional.Utils.getProjectNames;
 
 public class SpaceIntegrationTest extends RestTestBase {
 
@@ -110,7 +107,6 @@ public class SpaceIntegrationTest extends RestTestBase {
     }
 
     @Test
-    @Ignore("See https://issues.jboss.org/browse/DROOLS-2803")
     public void testDeleteExisting() {
         final String name = "spaceToBeDeleted";
         prepareSpace(name);

--- a/kie-wb-tests/kie-wb-tests-rest/src/test/java/org/kie/wb/test/rest/functional/TroubleshootRestSetupIssueIntegrationTest.java
+++ b/kie-wb-tests/kie-wb-tests-rest/src/test/java/org/kie/wb/test/rest/functional/TroubleshootRestSetupIssueIntegrationTest.java
@@ -1,0 +1,37 @@
+package org.kie.wb.test.rest.functional;
+
+import org.guvnor.rest.client.CreateProjectRequest;
+import org.guvnor.rest.client.Space;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.kie.wb.test.rest.RestTestBase;
+
+public class TroubleshootRestSetupIssueIntegrationTest extends RestTestBase {
+
+    @Test
+    @Ignore("This only serves to illustrate the issue, that sometimes deletion of space takes longer." +
+            "Please delete this test class when https://issues.jboss.org/browse/AF-1310 is fixed")
+    public void troubleshootSetupIssues() {
+        for (int i = 1; i < 50; i++) {
+            for (int j = 0; j < i; j++) {
+                final String
+                        spaceName = "space" + j,
+                        groupId = "cz.janhrcek";
+
+                final Space space = new Space();
+                space.setDefaultGroupId(groupId);
+                space.setName(spaceName);
+                space.setOwner("jan@rokycan.cz");
+                client.createSpace(space);
+
+                final CreateProjectRequest createProjectRequest = new CreateProjectRequest();
+                createProjectRequest.setGroupId(groupId);
+                createProjectRequest.setVersion("1." + j);
+                createProjectRequest.setName("project" + j);
+
+                client.createProject(spaceName, createProjectRequest);
+            }
+            deleteAllSpaces();
+        }
+    }
+}

--- a/kie-wb-tests/kie-wb-tests-rest/src/test/java/org/kie/wb/test/rest/security/ProjectAccessIntegrationTest.java
+++ b/kie-wb-tests/kie-wb-tests-rest/src/test/java/org/kie/wb/test/rest/security/ProjectAccessIntegrationTest.java
@@ -18,14 +18,12 @@ package org.kie.wb.test.rest.security;
 
 import org.guvnor.rest.client.CreateProjectRequest;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.kie.wb.test.rest.AccessRestTestBase;
 import org.kie.wb.test.rest.User;
 
-@Ignore("See https://issues.jboss.org/browse/DROOLS-2803")
 @RunWith(Parameterized.class)
 public class ProjectAccessIntegrationTest extends AccessRestTestBase {
 

--- a/kie-wb-tests/kie-wb-tests-rest/src/test/resources/logback-test.xml
+++ b/kie-wb-tests/kie-wb-tests-rest/src/test/resources/logback-test.xml
@@ -1,0 +1,15 @@
+<configuration>
+
+  <appender name="consoleAppender" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%date{HH:mm:ss.SSS} [%thread] %-5level %class{36}.%method:%line - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <logger name="org.kie.wb.test.rest" level="debug"/>
+
+  <root level="info">
+    <appender-ref ref="consoleAppender"/>
+  </root>
+
+</configuration>


### PR DESCRIPTION
Hello @Rikkola,
please check this. Troubleshooting instabilities in REST tests as discussed in email. The `@AfterClass` has been failing very often recently with similar errors:

```
org.kie.wb.test.rest.client.NotSuccessException: APPROVED: null
	at org.kie.wb.test.rest.client.RestWorkbenchClient.waitUntilJobFinished(RestWorkbenchClient.java:333)
	at org.kie.wb.test.rest.client.RestWorkbenchClient.waitUntilJobFinished(RestWorkbenchClient.java:303)
	at org.kie.wb.test.rest.client.RestWorkbenchClient.deleteSpace(RestWorkbenchClient.java:255)
	at org.kie.wb.test.rest.RestTestBase.deleteAllProject(RestTestBase.java:120)
	at org.kie.wb.test.rest.RestTestBase.cleanUp(RestTestBase.java:73)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:33)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.apache.maven.surefire.junit4.JUnit4Provider.execute(JUnit4Provider.java:283)
	at org.apache.maven.surefire.junit4.JUnit4Provider.executeWithRerun(JUnit4Provider.java:173)
	at org.apache.maven.surefire.junit4.JUnit4Provider.executeTestSet(JUnit4Provider.java:153)
	at org.apache.maven.surefire.junit4.JUnit4Provider.invoke(JUnit4Provider.java:128)
	at org.apache.maven.surefire.booter.ForkedBooter.invokeProviderInSameClassLoader(ForkedBooter.java:203)
	at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:155)
	at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:103)
```

1. Removed `deleteAllProject` because it was doing the same thing as `deleteAllSpaces` which is called at the same places.
2. Added debug logging to find out why the AfterClass cleanup is sometimes failing. By default there's 10 second timeout in the test client. The debug log are there to confirm we're exceeding the 10s timeout when it fails, in which case we might tweak the timeout / discuss if it's acceptable for space deletion to take so long.