### PR TITLE
Memory allocation to avoid OutOfMemoryError

### DIFF
--- a/kie-drools-wb-parent/kie-drools-wb-webapp/pom.xml
+++ b/kie-drools-wb-parent/kie-drools-wb-webapp/pom.xml
@@ -2372,7 +2372,7 @@
         </property>
       </activation>
       <properties>
-        <gwt.memory.settings>-Xmx4g -Xms1g -Xss1M</gwt.memory.settings>
+        <gwt.memory.settings>${gwt.memory.settings}</gwt.memory.settings>
         <gwt.compiler.localWorkers>4</gwt.compiler.localWorkers>
       </properties>
       <build>


### PR DESCRIPTION
fullProfile has too few memory and throws  OutOfMemoryError from times to times.
After this change it will use "default" profile with 6g instead of 4g.

See an example of failed build there: https://kie-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/kie-wb-common-downstream-pullrequests/1337/console