### PR TITLE
DROOLS-2846 : Move Verifier core from drools-wb to drools

### DIFF
--- a/kie-drools-wb-parent/kie-drools-wb-webapp/pom.xml
+++ b/kie-drools-wb-parent/kie-drools-wb-webapp/pom.xml
@@ -647,23 +647,33 @@
       <scope>runtime</scope>
     </dependency>
 
-    <!-- Drools Workbench Services -->
+    <!-- Verifier -->
     <dependency>
       <groupId>org.drools</groupId>
-      <artifactId>drools-wb-verifier-backend</artifactId>
-      <scope>runtime</scope>
+      <artifactId>drools-verifier-core</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.drools</groupId>
+      <artifactId>drools-wb-verifier-guided-decision-table-adapter</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.drools</groupId>
+      <artifactId>drools-wb-verifier-webworker</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.kie.workbench.services</groupId>
+      <artifactId>kie-wb-common-verifier-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.kie.workbench.services</groupId>
+      <artifactId>kie-wb-common-verifier-reporting</artifactId>
+      <scope>provided</scope>
     </dependency>
 
     <!-- Drools Workbench Screens -->
-    <dependency>
-      <groupId>org.drools</groupId>
-      <artifactId>drools-wb-verifier-api</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.drools</groupId>
-      <artifactId>drools-wb-verifier-client</artifactId>
-      <scope>provided</scope>
-    </dependency>
     <dependency>
       <groupId>org.drools</groupId>
       <artifactId>drools-wb-guided-rule-editor-api</artifactId>
@@ -1930,8 +1940,11 @@
               <compileSourcesArtifact>org.drools:drools-workbench-models-test-scenarios</compileSourcesArtifact>
 
               <!-- Drools WB -->
-              <compileSourcesArtifact>org.drools:drools-wb-verifier-api</compileSourcesArtifact>
-              <compileSourcesArtifact>org.drools:drools-wb-verifier-client</compileSourcesArtifact>
+              <compileSourcesArtifact>org.drools:drools-verifier-api</compileSourcesArtifact>
+              <compileSourcesArtifact>org.drools:drools-verifier-core</compileSourcesArtifact>
+              <compileSourcesArtifact>org.kie.workbench.services:kie-wb-common-verifier-api</compileSourcesArtifact>
+              <compileSourcesArtifact>org.kie.workbench.services:kie-wb-common-verifier-reporting</compileSourcesArtifact>
+              <compileSourcesArtifact>org.drools:drools-wb-verifier-guided-decision-table-adapter</compileSourcesArtifact>
               <compileSourcesArtifact>org.drools:drools-wb-enum-editor-api</compileSourcesArtifact>
               <compileSourcesArtifact>org.drools:drools-wb-enum-editor-client</compileSourcesArtifact>
               <compileSourcesArtifact>org.drools:drools-wb-drl-text-editor-api</compileSourcesArtifact>

--- a/kie-wb-parent/kie-wb-webapp/pom.xml
+++ b/kie-wb-parent/kie-wb-webapp/pom.xml
@@ -683,23 +683,33 @@
       <scope>runtime</scope>
     </dependency>
 
-    <!-- Drools Workbench Services -->
+    <!-- Verifier -->
     <dependency>
       <groupId>org.drools</groupId>
-      <artifactId>drools-wb-verifier-backend</artifactId>
-      <scope>runtime</scope>
+      <artifactId>drools-verifier-core</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.drools</groupId>
+      <artifactId>drools-wb-verifier-guided-decision-table-adapter</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.drools</groupId>
+      <artifactId>drools-wb-verifier-webworker</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.kie.workbench.services</groupId>
+      <artifactId>kie-wb-common-verifier-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.kie.workbench.services</groupId>
+      <artifactId>kie-wb-common-verifier-reporting</artifactId>
+      <scope>provided</scope>
     </dependency>
 
     <!-- Drools Workbench Screens -->
-    <dependency>
-      <groupId>org.drools</groupId>
-      <artifactId>drools-wb-verifier-api</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.drools</groupId>
-      <artifactId>drools-wb-verifier-client</artifactId>
-      <scope>provided</scope>
-    </dependency>
     <dependency>
       <groupId>org.drools</groupId>
       <artifactId>drools-wb-guided-rule-editor-client</artifactId>
@@ -2235,8 +2245,11 @@
             <compileSourcesArtifact>org.drools:drools-workbench-models-test-scenarios</compileSourcesArtifact>
 
             <!-- Drools WB -->
-            <compileSourcesArtifact>org.drools:drools-wb-verifier-api</compileSourcesArtifact>
-            <compileSourcesArtifact>org.drools:drools-wb-verifier-client</compileSourcesArtifact>
+            <compileSourcesArtifact>org.drools:drools-verifier-api</compileSourcesArtifact>
+            <compileSourcesArtifact>org.drools:drools-verifier-core</compileSourcesArtifact>
+            <compileSourcesArtifact>org.kie.workbench.services:kie-wb-common-verifier-api</compileSourcesArtifact>
+            <compileSourcesArtifact>org.kie.workbench.services:kie-wb-common-verifier-reporting</compileSourcesArtifact>
+            <compileSourcesArtifact>org.drools:drools-wb-verifier-guided-decision-table-adapter</compileSourcesArtifact>
             <compileSourcesArtifact>org.drools:drools-wb-enum-editor-api</compileSourcesArtifact>
             <compileSourcesArtifact>org.drools:drools-wb-enum-editor-client</compileSourcesArtifact>
             <compileSourcesArtifact>org.drools:drools-wb-drl-text-editor-api</compileSourcesArtifact>


### PR DESCRIPTION
https://issues.jboss.org/browse/DROOLS-2846
https://issues.jboss.org/browse/DROOLS-2847

Pretty much just moving code for the 99% of the changes and then 1% of refactorings to make the move easier.

Bundle:
https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/800
https://github.com/kiegroup/drools/pull/2021
https://github.com/kiegroup/kie-wb-common/pull/2054
https://github.com/kiegroup/drools-wb/pull/916
https://github.com/kiegroup/optaplanner-wb/pull/301
https://github.com/kiegroup/kie-wb-distributions/pull/795