### PR TITLE
DROOLS-2848 : Make the Verifier Web Worker connector reusable for different V&V types

### DIFF
--- a/kie-drools-wb-parent/kie-drools-wb-webapp/pom.xml
+++ b/kie-drools-wb-parent/kie-drools-wb-webapp/pom.xml
@@ -652,7 +652,7 @@
     </dependency>
     <dependency>
       <groupId>org.kie.workbench.services</groupId>
-      <artifactId>kie-wb-common-verifier-reporting</artifactId>
+      <artifactId>kie-wb-common-verifier-reporting-client</artifactId>
       <scope>provided</scope>
     </dependency>
 
@@ -1944,7 +1944,7 @@
               <compileSourcesArtifact>org.drools:drools-verifier-api</compileSourcesArtifact>
               <compileSourcesArtifact>org.drools:drools-verifier-core</compileSourcesArtifact>
               <compileSourcesArtifact>org.kie.workbench.services:kie-wb-common-verifier-api</compileSourcesArtifact>
-              <compileSourcesArtifact>org.kie.workbench.services:kie-wb-common-verifier-reporting</compileSourcesArtifact>
+              <compileSourcesArtifact>org.kie.workbench.services:kie-wb-common-verifier-reporting-client</compileSourcesArtifact>
               <compileSourcesArtifact>org.drools:drools-wb-verifier-guided-decision-table-adapter</compileSourcesArtifact>
               <compileSourcesArtifact>org.drools:drools-wb-enum-editor-api</compileSourcesArtifact>
               <compileSourcesArtifact>org.drools:drools-wb-enum-editor-client</compileSourcesArtifact>

--- a/kie-drools-wb-parent/kie-drools-wb-webapp/src/main/webapp/WEB-INF/web.xml
+++ b/kie-drools-wb-parent/kie-drools-wb-webapp/src/main/webapp/WEB-INF/web.xml
@@ -228,7 +228,7 @@
 
   <servlet>
     <servlet-name>VerifierWebWorkerServlet</servlet-name>
-    <servlet-class>org.drools.workbench.services.verifier.plugin.backend.VerifierWebWorkerServlet</servlet-class>
+    <servlet-class>org.kie.workbench.common.services.verifier.service.VerifierWebWorkerServlet</servlet-class>
   </servlet>
   <servlet-mapping>
     <servlet-name>VerifierWebWorkerServlet</servlet-name>

--- a/kie-wb-parent/kie-wb-webapp/pom.xml
+++ b/kie-wb-parent/kie-wb-webapp/pom.xml
@@ -688,7 +688,7 @@
     </dependency>
     <dependency>
       <groupId>org.kie.workbench.services</groupId>
-      <artifactId>kie-wb-common-verifier-reporting</artifactId>
+      <artifactId>kie-wb-common-verifier-reporting-client</artifactId>
       <scope>provided</scope>
     </dependency>
 
@@ -2249,7 +2249,7 @@
             <compileSourcesArtifact>org.drools:drools-verifier-api</compileSourcesArtifact>
             <compileSourcesArtifact>org.drools:drools-verifier-core</compileSourcesArtifact>
             <compileSourcesArtifact>org.kie.workbench.services:kie-wb-common-verifier-api</compileSourcesArtifact>
-            <compileSourcesArtifact>org.kie.workbench.services:kie-wb-common-verifier-reporting</compileSourcesArtifact>
+            <compileSourcesArtifact>org.kie.workbench.services:kie-wb-common-verifier-reporting-client</compileSourcesArtifact>
             <compileSourcesArtifact>org.drools:drools-wb-verifier-guided-decision-table-adapter</compileSourcesArtifact>
             <compileSourcesArtifact>org.drools:drools-wb-enum-editor-api</compileSourcesArtifact>
             <compileSourcesArtifact>org.drools:drools-wb-enum-editor-client</compileSourcesArtifact>

--- a/kie-wb-parent/kie-wb-webapp/src/main/webapp/WEB-INF/web.xml
+++ b/kie-wb-parent/kie-wb-webapp/src/main/webapp/WEB-INF/web.xml
@@ -230,7 +230,7 @@
 
   <servlet>
     <servlet-name>VerifierWebWorkerServlet</servlet-name>
-    <servlet-class>org.drools.workbench.services.verifier.plugin.backend.VerifierWebWorkerServlet</servlet-class>
+    <servlet-class>org.kie.workbench.common.services.verifier.service.VerifierWebWorkerServlet</servlet-class>
   </servlet>
   <servlet-mapping>
     <servlet-name>VerifierWebWorkerServlet</servlet-name>


### PR DESCRIPTION
Follow up for: https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/800

https://issues.jboss.org/browse/DROOLS-2848
https://issues.jboss.org/browse/DROOLS-2849

Bundle:
https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/809
https://github.com/kiegroup/kie-wb-common/pull/2073
https://github.com/kiegroup/drools-wb/pull/919
https://github.com/kiegroup/optaplanner-wb/pull/302
https://github.com/kiegroup/kie-wb-distributions/pull/802