### PR TITLE
Update breadcrumb locator in selenium tests

### DIFF
--- a/kie-wb-tests/kie-wb-tests-gui/src/main/java/org/kie/wb/selenium/model/persps/ExecutionErrorsPerspective.java
+++ b/kie-wb-tests/kie-wb-tests-gui/src/main/java/org/kie/wb/selenium/model/persps/ExecutionErrorsPerspective.java
@@ -21,7 +21,7 @@ import org.openqa.selenium.By;
 
 public class ExecutionErrorsPerspective extends AbstractPerspective {
 
-    private static final By EXECUTION_ERRORS_BREADCRUMB = ByJQuery.selector(".breadcrumb-last:contains('Manage Execution Errors')");
+    private static final By EXECUTION_ERRORS_BREADCRUMB = ByJQuery.selector(".breadcrumb-deactivated:contains('Manage Execution Errors')");
 
     @Override
     public boolean isDisplayed() {

--- a/kie-wb-tests/kie-wb-tests-gui/src/main/java/org/kie/wb/selenium/model/persps/JobsPerspective.java
+++ b/kie-wb-tests/kie-wb-tests-gui/src/main/java/org/kie/wb/selenium/model/persps/JobsPerspective.java
@@ -21,7 +21,7 @@ import org.openqa.selenium.By;
 
 public class JobsPerspective extends AbstractPerspective {
 
-    private static final By MANAGE_JOBS_BREADCRUMB = ByJQuery.selector(".breadcrumb-last:contains('Manage Jobs')");
+    private static final By MANAGE_JOBS_BREADCRUMB = ByJQuery.selector(".breadcrumb-deactivated:contains('Manage Jobs')");
 
     @Override
     public boolean isDisplayed() {

--- a/kie-wb-tests/kie-wb-tests-gui/src/main/java/org/kie/wb/selenium/model/persps/ProcessDashboardPerspective.java
+++ b/kie-wb-tests/kie-wb-tests-gui/src/main/java/org/kie/wb/selenium/model/persps/ProcessDashboardPerspective.java
@@ -23,7 +23,7 @@ import org.openqa.selenium.By;
 
 public class ProcessDashboardPerspective extends AbstractPerspective {
 
-    private static final By PROCESS_REPORTS_BREADCRUMB = ByJQuery.selector(".breadcrumb-last:contains('Process Reports')");
+    private static final By PROCESS_REPORTS_BREADCRUMB = ByJQuery.selector(".breadcrumb-deactivated:contains('Process Reports')");
 
     @Page
     private BusyPopup loadingIndicator;

--- a/kie-wb-tests/kie-wb-tests-gui/src/main/java/org/kie/wb/selenium/model/persps/ProcessDefinitionsPerspective.java
+++ b/kie-wb-tests/kie-wb-tests-gui/src/main/java/org/kie/wb/selenium/model/persps/ProcessDefinitionsPerspective.java
@@ -21,7 +21,7 @@ import org.openqa.selenium.By;
 
 public class ProcessDefinitionsPerspective extends AbstractPerspective {
 
-    private static final By PROCESS_DEFINITIONS_BREADCRUMB = ByJQuery.selector(".breadcrumb-last:contains('Manage Process Definitions')");
+    private static final By PROCESS_DEFINITIONS_BREADCRUMB = ByJQuery.selector(".breadcrumb-deactivated:contains('Manage Process Definitions')");
 
     @Override
     public boolean isDisplayed() {

--- a/kie-wb-tests/kie-wb-tests-gui/src/main/java/org/kie/wb/selenium/model/persps/ProcessInstancesPerspective.java
+++ b/kie-wb-tests/kie-wb-tests-gui/src/main/java/org/kie/wb/selenium/model/persps/ProcessInstancesPerspective.java
@@ -23,7 +23,7 @@ import org.openqa.selenium.By;
 
 public class ProcessInstancesPerspective extends AbstractPerspective {
 
-    private static final By PROCESS_INSTANCES_BREADCRUMB = ByJQuery.selector(".breadcrumb-last:contains('Manage Process Instances')");
+    private static final By PROCESS_INSTANCES_BREADCRUMB = ByJQuery.selector(".breadcrumb-deactivated:contains('Manage Process Instances')");
 
     @Page
     private BusyPopup busyPopup;

--- a/kie-wb-tests/kie-wb-tests-gui/src/main/java/org/kie/wb/selenium/model/persps/TaskAdminPerspective.java
+++ b/kie-wb-tests/kie-wb-tests-gui/src/main/java/org/kie/wb/selenium/model/persps/TaskAdminPerspective.java
@@ -21,7 +21,7 @@ import org.openqa.selenium.By;
 
 public class TaskAdminPerspective extends AbstractPerspective {
 
-    private static final By MANAGE_TASKS_BREADCRUMB = ByJQuery.selector(".breadcrumb-last:contains('Manage Tasks')");
+    private static final By MANAGE_TASKS_BREADCRUMB = ByJQuery.selector(".breadcrumb-deactivated:contains('Manage Tasks')");
 
     @Override
     public boolean isDisplayed() {

--- a/kie-wb-tests/kie-wb-tests-gui/src/main/java/org/kie/wb/selenium/model/persps/TaskDashboardPerspective.java
+++ b/kie-wb-tests/kie-wb-tests-gui/src/main/java/org/kie/wb/selenium/model/persps/TaskDashboardPerspective.java
@@ -23,7 +23,7 @@ import org.openqa.selenium.By;
 
 public class TaskDashboardPerspective extends AbstractPerspective {
 
-    private static final By TASK_REPORTS_BREADCRUMB = ByJQuery.selector(".breadcrumb-last:contains('Task Reports')");
+    private static final By TASK_REPORTS_BREADCRUMB = ByJQuery.selector(".breadcrumb-deactivated:contains('Task Reports')");
 
     @Page
     private BusyPopup loadingIndicator;

--- a/kie-wb-tests/kie-wb-tests-gui/src/main/java/org/kie/wb/selenium/model/persps/TasksPerspective.java
+++ b/kie-wb-tests/kie-wb-tests-gui/src/main/java/org/kie/wb/selenium/model/persps/TasksPerspective.java
@@ -23,7 +23,7 @@ import org.openqa.selenium.By;
 
 public class TasksPerspective extends AbstractPerspective {
 
-    private static final By TASK_INBOX_BREADCRUMB = ByJQuery.selector(".breadcrumb-last:contains('Task Inbox')");
+    private static final By TASK_INBOX_BREADCRUMB = ByJQuery.selector(".breadcrumb-deactivated:contains('Task Inbox')");
     @Page
     private BusyPopup loadingIndicator;
 


### PR DESCRIPTION
`LoadAllPerspectivesIntegrationTest` started to [fail on master](https://rhba-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/KIE/job/master/job/deployedRep/job/kie-wb-distributions/) with `Perspective Process Definitions should be loaded`. The root cause: jquery locator used to detect that the perspective was loaded was no longer valid - css class name was changed in https://github.com/kiegroup/appformer/pull/437 (CC @paulovmr). This PR fixes the test by updating the locator. 

Thanks to @domhanak for pointing this failure out to me