### PR TITLE
Disable incremental build in workbench rest / selenium tests

### DIFF
--- a/kie-wb-tests/pom.xml
+++ b/kie-wb-tests/pom.xml
@@ -319,6 +319,8 @@
                     <org.uberfire.nio.git.daemon.port>${cargo.git.port}</org.uberfire.nio.git.daemon.port>
                     <org.uberfire.nio.git.ssh.enabled>false</org.uberfire.nio.git.ssh.enabled>
                     <datasource.management.wildfly.port>${cargo.management.port}</datasource.management.wildfly.port>
+                    <!-- disable incremental build to make tests less IO intensive and more stable (https://issues.jboss.org/browse/AF-1310) -->
+                    <build.enable-incremental>false</build.enable-incremental>
                   </systemProperties>
                 </container>
                 <configuration>


### PR DESCRIPTION
Now that Paulo fixed the problem with overriding system properties in https://github.com/kiegroup/appformer/pull/467 I'm disabling incremental build using system property given in cargo container configuration used by workbench rest tests as well as by selenium tests.