### PR TITLE
Prevent home page loading timeouts in selenium tests

### DIFF
--- a/kie-wb-tests/kie-wb-tests-gui/README.md
+++ b/kie-wb-tests/kie-wb-tests-gui/README.md
@@ -1,14 +1,18 @@
 # KIE Workbench GUI tests (selenium)
 
-Before the tests run, container is started (using cargo maven plugin) with kie-wb deployed.
+Before the tests run, container is started (using cargo-maven2-plugin) with kie-wb deployed.
 These tests require Firefox to be available on the system.
 
 ## Running from CLI
 
-You have to provide path to firefox binary.
-Selenium usually supports the latest two ESR versions (54 and 60 at the time I'm writing this).
+To run the tests you have to:
+- provide path to firefox binary by setting `-Dwebdriver.firefox.bin=/path/to/firefox-bin`. Selenium usually supports the latest two ESR versions (54 and 60 at the time I'm writing this).- 
+- enable container profile (wildflyXX) to enable cargo configuration which starts container with kie-wb deployed
 
 ```bash
 cd kie-wb-distributions/kie-wb-tests/kie-wb-tests-gui/
 mvn clean verify -Pkie-wb,wildfly11 -Dwebdriver.firefox.bin=/path/to/firefox/firefox-bin
 ```
+
+By default the tests are using headless firefox, so the browser window is not shown.
+If you want to view the browser window as the tests are running, remove `<property name="firefoxArguments">-headless</property>` from [arquillian.xml](https://github.com/kiegroup/kie-wb-distributions/blob/master/kie-wb-tests/kie-wb-tests-gui/src/test/filtered-resources/arquillian.xml).

--- a/kie-wb-tests/kie-wb-tests-gui/pom.xml
+++ b/kie-wb-tests/kie-wb-tests-gui/pom.xml
@@ -15,7 +15,7 @@
 
   <properties>
     <app.name>kie-wb</app.name><!-- for tests to know if they are running against kie-wb or kie-drools-wb -->
-    <selenium.homepage.loading.timeout.seconds>15</selenium.homepage.loading.timeout.seconds>
+    <selenium.homepage.loading.timeout.seconds>30</selenium.homepage.loading.timeout.seconds>
     <!-- default browser to be used by selenium tests -->
     <browser>firefox</browser>
     <!-- path to firefox binary specified externally via -Dwebdriver.firefox.bin=... -->

--- a/kie-wb-tests/kie-wb-tests-gui/src/main/java/org/kie/wb/selenium/model/persps/HomePerspective.java
+++ b/kie-wb-tests/kie-wb-tests-gui/src/main/java/org/kie/wb/selenium/model/persps/HomePerspective.java
@@ -15,12 +15,17 @@
  */
 package org.kie.wb.selenium.model.persps;
 
+import java.time.Duration;
+
 import org.kie.wb.selenium.util.Waits;
 import org.openqa.selenium.By;
 import org.openqa.selenium.NoSuchElementException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class HomePerspective extends AbstractPerspective {
 
+    private static final Logger LOG = LoggerFactory.getLogger(HomePerspective.class);
     private static final By HOME_CONTENT = By.className("kie-page");
     private static final int DEFAULT_HOME_PERSP_LOADING_TIMEOUT_SECONDS = 15;
     // Troubleshooting webapp loading issues on tomcat / jenkins slaves where the default 15 seconds is not enough
@@ -28,7 +33,11 @@ public class HomePerspective extends AbstractPerspective {
 
     @Override
     public void waitForLoaded() {
+        long start = System.currentTimeMillis();
         Waits.elementPresent(HOME_CONTENT, HOME_PERSP_LOADING_TIMEOUT_SECONDS);
+        long homePageLoadingDurationMillis = System.currentTimeMillis() - start;
+        Duration loadingDuration = Duration.ofMillis(homePageLoadingDurationMillis);
+        LOG.info("It took {} seconds to load home page.", loadingDuration.getSeconds());
     }
 
     @Override


### PR DESCRIPTION
The root cause of these timeouts is the time it takes to download and execute the 23MB main workbench javascript file (compiled from GWT).

Even on my overpowered laptop the initial load of the home page takes ~13 seconds, so the default 15s home page loading timeout is unreasonably small.
Bumping the default to 30 seconds and adding log message so we can check later how slow the loading was.