### PR TITLE
[DO NOT MERGE] BAQE-650: Remove drools.datetimeformat property

### DIFF
--- a/kie-drools-wb-parent/kie-drools-wb-webapp/src/main/java/org/kie/workbench/drools/backend/server/AppSetup.java
+++ b/kie-drools-wb-parent/kie-drools-wb-webapp/src/main/java/org/kie/workbench/drools/backend/server/AppSetup.java
@@ -102,8 +102,6 @@ public class AppSetup extends BaseAppSetup {
                                                                        "" );
         group.addConfigItem( configurationFactory.newConfigItem( "drools.dateformat",
                                                                  "dd-MMM-yyyy" ) );
-        group.addConfigItem( configurationFactory.newConfigItem( "drools.datetimeformat",
-                                                                 "dd-MMM-yyyy HH:mm:ss" ) );
         group.addConfigItem( configurationFactory.newConfigItem( "drools.defaultlanguage",
                                                                  "en" ) );
         group.addConfigItem( configurationFactory.newConfigItem( "drools.defaultcountry",

--- a/kie-wb-parent/kie-wb-webapp/src/main/java/org/kie/workbench/backend/AppSetup.java
+++ b/kie-wb-parent/kie-wb-webapp/src/main/java/org/kie/workbench/backend/AppSetup.java
@@ -99,8 +99,6 @@ public class AppSetup extends BaseAppSetup {
                                                                        "" );
         group.addConfigItem( configurationFactory.newConfigItem( "drools.dateformat",
                                                                  "dd-MMM-yyyy" ) );
-        group.addConfigItem( configurationFactory.newConfigItem( "drools.datetimeformat",
-                                                                 "dd-MMM-yyyy HH:mm:ss" ) );
         group.addConfigItem( configurationFactory.newConfigItem( "drools.defaultlanguage",
                                                                  "en" ) );
         group.addConfigItem( configurationFactory.newConfigItem( "drools.defaultcountry",


### PR DESCRIPTION
After investigating the codebase it seems that the system property drools.datetimeformat is set, but never used. So this PR removest. The time format pask for dates can be set using drools.dateformat property.

Ensemble with:
- https://github.com/kiegroup/drools-wb/pull/954
- https://github.com/kiegroup/kie-wb-common/pull/2173
- https://github.com/kiegroup/optaplanner-wb/pull/307