### PR TITLE
Fix RepositoryIntegrationTest when running tests with eap7 container profile

### DIFF
--- a/kie-wb-tests/pom.xml
+++ b/kie-wb-tests/pom.xml
@@ -379,6 +379,7 @@
              here or via system property when running the build (don't forget to use the `file://` prefix when
              referencing the zip from local filesystem). -->
         <eap7.download.url>valid-url-for-eap-7-zip-needs-to-be-specified-here-or-via-cmd-line</eap7.download.url>
+        <cargo.git.port>9418</cargo.git.port>
       </properties>
       <build>
         <pluginManagement>


### PR DESCRIPTION
@toni @ederign @cristianonicolai this fixes the [integration test failure](https://rhba-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/KIE/job/7.11.x/job/dailyBuild/job/kieWbTestsMatrix-kieAllBuild-7.11.x/lastCompletedBuild/browser=firefox,container=eap7,jdk=kie-jdk1.8,label_exp=kie-linux&&kie-mem8g&&gui-testing,war=kie-wb/testReport/org.kie.wb.test.rest.functional/RepositoryIntegrationTest/testCloneRepositoryInternal/) that @mbiarnes emailed us about.

The root cause was that the tests initialized [org.uberfire.nio.git.daemon.port to null](https://github.com/kiegroup/kie-wb-distributions/blob/master/kie-wb-tests/kie-wb-tests-rest/src/test/java/org/kie/wb/test/rest/RestTestBase.java#L48) because eap7 container profile in the pom wasn't setting `cargo.git.port` property (fixed in this PR) which is used in maven-failsafe-plugin configuration to [initialize the port property for the rest tests](https://github.com/kiegroup/kie-wb-distributions/blob/master/kie-wb-tests/pom.xml#L180).

General issue I see: only Michael B. is looking at the results of tests in the upstream. To fix the builds either he should be more vocal about it (spam "test authors" about the failures or file jiras for them) or we should make more people aware that some jobs exist and people should be notified of the failures. @mbiarnes thanks for bringing that failure to our attention.

Another general issue I see: system properties create implicit dependence on external environment and make all kinds of failures like this possible. We should avoid using them whenever possible.
