### PR TITLE
Remove useless property override

### DIFF
--- a/kie-server-distributions/pom.xml
+++ b/kie-server-distributions/pom.xml
@@ -13,7 +13,6 @@
 
   <properties>
     <version.org.postgresql>42.2.1</version.org.postgresql>
-    <version.org.wildfly>14.0.1.Final</version.org.wildfly>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
kie-server-distributions overrides 'version.org.wildfly' defined in kie-parent from '14.0.1.Final' to the same version '14.0.1.Final'
This override is unnecessary and will require changes in more places when we update wildfly in the future (or will be forgotten and will cause inconsistencies).
@cristianonicolai please check and consider merging