### PR TITLE
Unignore test after RHPAM-581 fixed

### DIFF
--- a/business-central-tests/business-central-tests-gui/src/main/java/org/kie/wb/selenium/model/persps/ProcessDashboardPerspective.java
+++ b/business-central-tests/business-central-tests-gui/src/main/java/org/kie/wb/selenium/model/persps/ProcessDashboardPerspective.java
@@ -15,7 +15,6 @@
  */
 package org.kie.wb.selenium.model.persps;
 
-import org.jboss.arquillian.graphene.page.Page;
 import org.kie.wb.selenium.util.BusyPopup;
 import org.kie.wb.selenium.util.Waits;
 import org.openqa.selenium.By;
@@ -24,9 +23,6 @@ public class ProcessDashboardPerspective extends AbstractPerspective {
 
     private static final By PROCESS_REPORTS_BREADCRUMB = By.xpath("//a[contains(text(), 'Process Reports')]");
 
-    @Page
-    private BusyPopup loadingIndicator;
-
     @Override
     public boolean isDisplayed() {
         return Waits.isElementPresent(PROCESS_REPORTS_BREADCRUMB);
@@ -34,6 +30,6 @@ public class ProcessDashboardPerspective extends AbstractPerspective {
 
     @Override
     public void waitForLoaded() {
-        loadingIndicator.waitForDisappearance();
+        BusyPopup.waitForDisappearance();
     }
 }

--- a/business-central-tests/business-central-tests-gui/src/main/java/org/kie/wb/selenium/model/persps/ProcessInstancesPerspective.java
+++ b/business-central-tests/business-central-tests-gui/src/main/java/org/kie/wb/selenium/model/persps/ProcessInstancesPerspective.java
@@ -15,7 +15,6 @@
  */
 package org.kie.wb.selenium.model.persps;
 
-import org.jboss.arquillian.graphene.page.Page;
 import org.kie.wb.selenium.util.BusyPopup;
 import org.kie.wb.selenium.util.Waits;
 import org.openqa.selenium.By;
@@ -24,9 +23,6 @@ public class ProcessInstancesPerspective extends AbstractPerspective {
 
     private static final By PROCESS_INSTANCES_BREADCRUMB = By.xpath("//a[contains(text(), 'Manage Process Instances')]");
 
-    @Page
-    private BusyPopup busyPopup;
-
     @Override
     public boolean isDisplayed() {
         return Waits.isElementPresent(PROCESS_INSTANCES_BREADCRUMB);
@@ -34,6 +30,6 @@ public class ProcessInstancesPerspective extends AbstractPerspective {
 
     @Override
     public void waitForLoaded() {
-        busyPopup.waitForDisappearance();
+        BusyPopup.waitForDisappearance();
     }
 }

--- a/business-central-tests/business-central-tests-gui/src/main/java/org/kie/wb/selenium/model/persps/TaskDashboardPerspective.java
+++ b/business-central-tests/business-central-tests-gui/src/main/java/org/kie/wb/selenium/model/persps/TaskDashboardPerspective.java
@@ -15,7 +15,6 @@
  */
 package org.kie.wb.selenium.model.persps;
 
-import org.jboss.arquillian.graphene.page.Page;
 import org.kie.wb.selenium.util.BusyPopup;
 import org.kie.wb.selenium.util.Waits;
 import org.openqa.selenium.By;
@@ -24,9 +23,6 @@ public class TaskDashboardPerspective extends AbstractPerspective {
 
     private static final By TASK_REPORTS_BREADCRUMB = By.xpath("//a[contains(text(), 'Task Reports')]");
 
-    @Page
-    private BusyPopup loadingIndicator;
-
     @Override
     public boolean isDisplayed() {
         return Waits.isElementPresent(TASK_REPORTS_BREADCRUMB);
@@ -34,6 +30,6 @@ public class TaskDashboardPerspective extends AbstractPerspective {
 
     @Override
     public void waitForLoaded() {
-        loadingIndicator.waitForDisappearance();
+        BusyPopup.waitForDisappearance();
     }
 }

--- a/business-central-tests/business-central-tests-gui/src/main/java/org/kie/wb/selenium/model/persps/TasksPerspective.java
+++ b/business-central-tests/business-central-tests-gui/src/main/java/org/kie/wb/selenium/model/persps/TasksPerspective.java
@@ -15,7 +15,6 @@
  */
 package org.kie.wb.selenium.model.persps;
 
-import org.jboss.arquillian.graphene.page.Page;
 import org.kie.wb.selenium.util.BusyPopup;
 import org.kie.wb.selenium.util.Waits;
 import org.openqa.selenium.By;
@@ -23,8 +22,6 @@ import org.openqa.selenium.By;
 public class TasksPerspective extends AbstractPerspective {
 
     private static final By TASK_INBOX_BREADCRUMB = By.xpath("//a[contains(text(), 'Task Inbox')]");
-    @Page
-    private BusyPopup loadingIndicator;
 
     @Override
     public boolean isDisplayed() {
@@ -33,6 +30,6 @@ public class TasksPerspective extends AbstractPerspective {
 
     @Override
     public void waitForLoaded() {
-        loadingIndicator.waitForDisappearance();
+        BusyPopup.waitForDisappearance();
     }
 }

--- a/business-central-tests/business-central-tests-gui/src/main/java/org/kie/wb/selenium/model/persps/authoring/ImportProjectsScreen.java
+++ b/business-central-tests/business-central-tests-gui/src/main/java/org/kie/wb/selenium/model/persps/authoring/ImportProjectsScreen.java
@@ -23,7 +23,6 @@ import org.kie.wb.selenium.util.Waits;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
-import org.openqa.selenium.support.PageFactory;
 
 import static org.kie.wb.selenium.util.ByUtil.xpath;
 
@@ -58,7 +57,6 @@ public class ImportProjectsScreen extends PageObject {
     }
 
     public void waitForLoaded() {
-        BusyPopup indicator = PageFactory.initElements(driver, BusyPopup.class);
-        indicator.waitForDisappearance();
+        BusyPopup.waitForDisappearance();
     }
 }

--- a/business-central-tests/business-central-tests-gui/src/main/java/org/kie/wb/selenium/model/widgets/ModalDialog.java
+++ b/business-central-tests/business-central-tests-gui/src/main/java/org/kie/wb/selenium/model/widgets/ModalDialog.java
@@ -16,21 +16,21 @@
 package org.kie.wb.selenium.model.widgets;
 
 import org.jboss.arquillian.graphene.Graphene;
-import org.jboss.arquillian.graphene.findby.FindByJQuery;
 import org.kie.wb.selenium.model.PageObject;
 import org.kie.wb.selenium.util.Waits;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
 
-import static org.kie.wb.selenium.util.ByUtil.jquery;
+import static org.kie.wb.selenium.util.ByUtil.xpath;
 
 public class ModalDialog extends PageObject {
 
-    @FindByJQuery("button.close")
+    @FindBy(className = "close")
     private WebElement closeButton;
 
     public static <T extends ModalDialog> T newInstance(Class<T> pageFragmentClass, String modalTitle) {
-        By modalRootLocator = jquery(".modal-content:has(.modal-header:contains('%s'))", modalTitle);
+        By modalRootLocator = xpath("//div[@class='modal-content' and div[@class='modal-header'][h4[contains(text(),'%s')]]]", modalTitle);
         WebElement modalRoot = Waits.elementPresent(modalRootLocator);
         return Graphene.createPageFragment(pageFragmentClass, modalRoot);
     }
@@ -53,8 +53,8 @@ public class ModalDialog extends PageObject {
         clickButton("Next");
     }
 
-    public void clickButton(String buttonText) {
-        By buttonLoc = jquery(".modal-footer > .btn:contains('%s'):not([disabled])", buttonText);
+    protected void clickButton(String buttonText) {
+        By buttonLoc = xpath("//div[@class='modal-footer']/button[contains(@class,'btn') and contains(text(),'%s')]", buttonText);
         WebElement button = Waits.elementPresent(buttonLoc);
         button.click();
     }

--- a/business-central-tests/business-central-tests-gui/src/test/java/org/kie/wb/selenium/ui/ProjectLibraryIntegrationTest.java
+++ b/business-central-tests/business-central-tests-gui/src/test/java/org/kie/wb/selenium/ui/ProjectLibraryIntegrationTest.java
@@ -16,7 +16,6 @@
 package org.kie.wb.selenium.ui;
 
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.kie.wb.selenium.model.KieSeleniumTest;
 import org.kie.wb.selenium.model.persps.ArtifactRepositoryPerspective;
@@ -47,27 +46,24 @@ public class ProjectLibraryIntegrationTest extends KieSeleniumTest {
                 projectGav = "optacloud:optacloud:1.0.0-SNAPSHOT";
 
         importBuildDeployAndCheckArtifact(
-                projectName,
                 projectGav,
                 () -> projectLibrary.importStockExampleProject(projectName)
         );
     }
 
     @Test
-    @Ignore("RHBA-581 - [Project Oriented] Impossible to delete 'broken projects'")
     public void importAndBuildProjectFromCustomRepository() {
         final String
                 projectName = "Evaluation",
                 projectGav = "org.jbpm:Evaluation:1.0";
 
         importBuildDeployAndCheckArtifact(
-                projectName,
                 projectGav,
                 () -> projectLibrary.importCustomExampleProject(Repository.JBPM_PLAYGROUND, projectName)
         );
     }
 
-    private void importBuildDeployAndCheckArtifact(String projectName, String projectGav, Runnable stepsToImportProject) {
+    private void importBuildDeployAndCheckArtifact(String projectGav, Runnable stepsToImportProject) {
         stepsToImportProject.run();
         //Wait for success alert to hide
         Waits.pause(5_000);


### PR DESCRIPTION
@Rikkola please check
Main change: unignore test which was ignored because of [RHPAM-581](https://issues.jboss.org/browse/RHPAM-581) which was fixed some time ago.
The rest are just fixes to IntelliJ warnings in the selenium test module.