### PR TITLE
Prevent occasional failures in selenium tests

### DIFF
--- a/business-central-tests/business-central-tests-gui/src/main/java/org/kie/wb/selenium/model/PrimaryNavbar.java
+++ b/business-central-tests/business-central-tests-gui/src/main/java/org/kie/wb/selenium/model/PrimaryNavbar.java
@@ -20,7 +20,6 @@ import org.kie.wb.selenium.model.persps.AbstractPerspective;
 import org.kie.wb.selenium.model.persps.AdminPagePerspective;
 import org.kie.wb.selenium.model.persps.ProjectLibraryPerspective;
 import org.kie.wb.selenium.model.widgets.DropdownMenu;
-import org.kie.wb.selenium.util.BusyPopup;
 import org.kie.wb.selenium.util.Waits;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
@@ -31,6 +30,7 @@ import org.slf4j.LoggerFactory;
 import static org.kie.wb.selenium.model.KieSeleniumTest.driver;
 import static org.kie.wb.selenium.util.ByUtil.css;
 import static org.kie.wb.selenium.util.ByUtil.jquery;
+import static org.kie.wb.selenium.util.ObstructedClickExceptionHandler.retryClickUntilNotObstructed;
 
 public class PrimaryNavbar {
 
@@ -75,7 +75,7 @@ public class PrimaryNavbar {
         if ("N/A".equals(menuName)) {
             final By itemLink = css("a[title='%s']", itemName);
             Waits.elementPresent(itemLink);
-            BusyPopup.retryClickUntilPopupDisappears(navbar.findElement(itemLink));
+            retryClickUntilNotObstructed(navbar.findElement(itemLink));
         } else {
             WebElement menuRoot = driver.findElement(jquery(NAVBAR_MENU));
             DropdownMenu menu = Graphene.createPageFragment(DropdownMenu.class, menuRoot);

--- a/business-central-tests/business-central-tests-gui/src/main/java/org/kie/wb/selenium/model/persps/AbstractPerspective.java
+++ b/business-central-tests/business-central-tests-gui/src/main/java/org/kie/wb/selenium/model/persps/AbstractPerspective.java
@@ -20,13 +20,13 @@ import org.jboss.arquillian.graphene.page.Page;
 import org.kie.wb.selenium.model.PageObject;
 import org.kie.wb.selenium.model.PrimaryNavbar;
 import org.kie.wb.selenium.model.widgets.Panel;
-import org.kie.wb.selenium.util.BusyPopup;
 import org.kie.wb.selenium.util.Waits;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
 
 import static org.kie.wb.selenium.util.ByUtil.jquery;
+import static org.kie.wb.selenium.util.ObstructedClickExceptionHandler.retryClickUntilNotObstructed;
 
 public abstract class AbstractPerspective extends PageObject {
 
@@ -62,6 +62,6 @@ public abstract class AbstractPerspective extends PageObject {
 
     public void click(By locatorOfThingToClick) {
         WebElement thingToClick = Waits.elementPresent(locatorOfThingToClick);
-        BusyPopup.retryClickUntilPopupDisappears(thingToClick);
+        retryClickUntilNotObstructed(thingToClick);
     }
 }

--- a/business-central-tests/business-central-tests-gui/src/main/java/org/kie/wb/selenium/model/widgets/DropdownMenu.java
+++ b/business-central-tests/business-central-tests-gui/src/main/java/org/kie/wb/selenium/model/widgets/DropdownMenu.java
@@ -16,11 +16,12 @@
 package org.kie.wb.selenium.model.widgets;
 
 import org.jboss.arquillian.graphene.fragment.Root;
-import org.kie.wb.selenium.util.BusyPopup;
 import org.kie.wb.selenium.util.Waits;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
+
+import static org.kie.wb.selenium.util.ObstructedClickExceptionHandler.retryClickUntilNotObstructed;
 
 public class DropdownMenu {
 
@@ -33,7 +34,7 @@ public class DropdownMenu {
 
     private void open() {
         Waits.elementClickable(By.cssSelector(DROPDOWN_TOGGLE));
-        BusyPopup.retryClickUntilPopupDisappears(dropdownToggle);
+        retryClickUntilNotObstructed(dropdownToggle);
     }
 
     private boolean isOpened() {

--- a/business-central-tests/business-central-tests-gui/src/main/java/org/kie/wb/selenium/util/BusyPopup.java
+++ b/business-central-tests/business-central-tests-gui/src/main/java/org/kie/wb/selenium/util/BusyPopup.java
@@ -26,7 +26,7 @@ import org.slf4j.LoggerFactory;
 public class BusyPopup extends PageObject {
 
     private static final String GLASS_CSS_CLASS = "gwt-PopupPanelGlass";
-    private static final Logger LOG = LoggerFactory.getLogger(BusyPopup.class);
+
 
     public static void waitForDisappearance() {
         By glass = By.className(GLASS_CSS_CLASS);
@@ -34,40 +34,5 @@ public class BusyPopup extends PageObject {
         Waits.pause(500);
     }
 
-    /*
-     * In Chrome and Firefox click operation might fail if there is gwt-PopupPanelGlass in the way.
-     * This method ignores click failures caused by this particular exception and retries the click fixed number of times or until the glass disappears
-     */
-    public static void retryClickUntilPopupDisappears(WebElement element) {
-        int triesRemaining = 100;
-        boolean firstTime = true;
-        while (triesRemaining > 0) {
-            try {
-                element.click();
-                return;
-            } catch (WebDriverException e) {
-                if (isGlassException(e)) {
-                    triesRemaining--;
-                    if (firstTime) {
-                        firstTime = false;
-                        String firstLineOfExceptionMessage = e.getMessage().split("\n")[0];
-                        LOG.warn("Clicking element {} failed: {}",
-                                 element,
-                                 firstLineOfExceptionMessage);
-                    } else {
-                        LOG.debug("Retrying click, {} tries remaining.",
-                                  triesRemaining);
-                    }
-                    Waits.pause(100);
-                } else {
-                    throw e;
-                }
-            }
-        }
-    }
 
-    private static boolean isGlassException(WebDriverException e) {
-        // Be careful when changing this condition; the exact exception message might differ on FF vs. Chrome.
-        return e.getMessage().contains(GLASS_CSS_CLASS);
-    }
 }

--- a/business-central-tests/business-central-tests-gui/src/main/java/org/kie/wb/selenium/util/ObstructedClickExceptionHandler.java
+++ b/business-central-tests/business-central-tests-gui/src/main/java/org/kie/wb/selenium/util/ObstructedClickExceptionHandler.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.wb.selenium.util;
+
+import org.openqa.selenium.WebDriverException;
+import org.openqa.selenium.WebElement;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ObstructedClickExceptionHandler {
+
+    private static final Logger LOG = LoggerFactory.getLogger(BusyPopup.class);
+
+    /*
+     * Clicking an element might fail if there is gwt-PopupPanelGlass or alert in the way.
+     * This method ignores click failures caused by WebDriverException's like
+     *
+     * <pre>
+     * Element <button id="deploy" class="btn btn-default" type="button"> is not clickable at point (1213.5,128.60000610351562)
+     * because another element <div class="alert alert-dismissable alert-success"> obscures it
+     * </pre>
+     *
+     * and retries clicking until the obstructing element disappears
+     *
+     *
+     * WARNING: the standard selenium way of dealing with these exceptions (waiting for something to become true
+     * using WebDriverWait) doesn't work because of the non-predictable nature of these popups/alerts,
+     * so it's not clear where such waits should be placed.
+     */
+    public static void retryClickUntilNotObstructed(WebElement element) {
+        int triesRemaining = 100;
+        boolean firstTime = true;
+        while (triesRemaining > 0) {
+            try {
+                element.click();
+                return;
+            } catch (WebDriverException e) {
+                if (isClickObstructedByPopupPanelGlass(e) || isClickObstructedByAlert(e)) {
+                    triesRemaining--;
+                    if (firstTime) {
+                        firstTime = false;
+                        String firstLineOfExceptionMessage = e.getMessage().split("\n")[0];
+                        LOG.warn("Clicking element {} failed: {}",
+                                 element,
+                                 firstLineOfExceptionMessage);
+                    } else {
+                        LOG.debug("Retrying click, {} tries remaining.",
+                                  triesRemaining);
+                    }
+                    Waits.pause(100);
+                } else {
+                    throw e;
+                }
+            }
+        }
+    }
+
+    private static boolean isClickObstructedByPopupPanelGlass(WebDriverException e) {
+        return e.getMessage().contains("gwt-PopupPanelGlass");
+    }
+
+    private static boolean isClickObstructedByAlert(WebDriverException e) {
+        return e.getMessage().contains("alert-dismissable");
+    }
+}


### PR DESCRIPTION
@manstis please check. About once a week selenium test [ProjectLibraryIntegrationTest#importAndBuildProjectFromCustomRepository](http://janhrcek.cz/random-failures/#/class/org.kie.wb.selenium.ui.ProjectLibraryIntegrationTest/method/importAndBuildProjectFromCustomRepository) 
fails due to click on "build" button being blocked by "Project imported successfully" notification.

Work around that by ignoring the "element is not clickable.. because other element obscures it" exception and try clicking again.