### PR TITLE
AF-1817: Gzip filter

### DIFF
--- a/business-central-parent/business-central-webapp/src/main/webapp/WEB-INF/web.xml
+++ b/business-central-parent/business-central-webapp/src/main/webapp/WEB-INF/web.xml
@@ -156,6 +156,16 @@
     <url-pattern>/websocket/*</url-pattern>
   </filter-mapping>
 
+  <filter>
+    <filter-name>GzipFilter</filter-name>
+    <filter-class>org.uberfire.backend.server.util.gzip.GzipFilter</filter-class>
+  </filter>
+
+  <filter-mapping>
+    <filter-name>GzipFilter</filter-name>
+    <url-pattern>*.js</url-pattern>
+  </filter-mapping>
+
   <!-- drools-wb servlets -->
   <servlet>
     <servlet-name>DTableXLSFileServlet</servlet-name>

--- a/business-central-parent/business-monitoring-webapp/src/main/webapp/WEB-INF/web.xml
+++ b/business-central-parent/business-monitoring-webapp/src/main/webapp/WEB-INF/web.xml
@@ -137,6 +137,16 @@
     <url-pattern>/ws/*</url-pattern>
   </filter-mapping>
 
+  <filter>
+    <filter-name>GzipFilter</filter-name>
+    <filter-class>org.uberfire.backend.server.util.gzip.GzipFilter</filter-class>
+  </filter>
+
+  <filter-mapping>
+    <filter-name>GzipFilter</filter-name>
+    <url-pattern>*.js</url-pattern>
+  </filter-mapping>
+
   <!-- Basic Auth Filter for WebSocket endpoints -->
   <filter>
     <filter-name>WebSocket Basic Auth Filter</filter-name>


### PR DESCRIPTION
This PR configures the Gzip filter introduced on the related PR in kiegroup/appformer.

This filter intercepts requests for the configured `url-pattern` matching resources and checks for the "gzip" `Accept-Encoding` HTTP header. If it's present, the filter compresses the requested asset in Gzip format, reducing its size and therefore optimizing its download.

This is particularly important for the GWT JavaScript bundles, which originally have around 30MB. **After gzip compression, the bundles are only around 6MB.**

Related PRs:
https://github.com/kiegroup/appformer/pull/631
https://github.com/kiegroup/kie-wb-distributions/pull/877
https://github.com/kiegroup/kie-docs/pull/1395

