### PR TITLE
AF-1821: Readiness and Liveness endpoints

### DIFF
--- a/business-central-parent/business-central-webapp/src/main/webapp/WEB-INF/web.xml
+++ b/business-central-parent/business-central-webapp/src/main/webapp/WEB-INF/web.xml
@@ -128,6 +128,10 @@
       <param-name>realmName</param-name>
       <param-value>Business Central Realm</param-value>
     </init-param>
+    <init-param>
+      <param-name>excludedPaths</param-name>
+      <param-value>/rest/healthy,/rest/ready</param-value>
+    </init-param>
   </filter>
 
   <filter-mapping>

--- a/business-central-parent/business-monitoring-webapp/src/main/webapp/WEB-INF/web.xml
+++ b/business-central-parent/business-monitoring-webapp/src/main/webapp/WEB-INF/web.xml
@@ -128,6 +128,10 @@
       <param-name>realmName</param-name>
       <param-value>Business Central Realm</param-value>
     </init-param>
+    <init-param>
+      <param-name>excludedPaths</param-name>
+      <param-value>/rest/healthy,/rest/ready</param-value>
+    </init-param>
   </filter>
 
   <filter-mapping>


### PR DESCRIPTION
This PR configures the excludedPaths parameter on `BasicAuthSecurityFilter` for rest services to exclude `/rest/healthy` and `/rest/ready` URIs from authentication.

Related PRs:
https://github.com/kiegroup/appformer/pull/645
https://github.com/kiegroup/kie-wb-common/pull/2492
https://github.com/kiegroup/kie-wb-distributions/pull/881