### PR TITLE
JBPM-6848: Form Generation fails generating forms for classes on external dependencies

### DIFF
--- a/business-central-parent/business-monitoring-webapp/pom.xml
+++ b/business-central-parent/business-monitoring-webapp/pom.xml
@@ -1263,6 +1263,17 @@
 
     <dependency>
       <groupId>org.kie.workbench.forms</groupId>
+      <artifactId>kie-wb-common-forms-data-modeller-integration-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.kie.workbench.forms</groupId>
+      <artifactId>kie-wb-common-forms-data-modeller-integration-backend</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.kie.workbench.forms</groupId>
       <artifactId>kie-wb-common-forms-jbpm-integration-api</artifactId>
     </dependency>
 


### PR DESCRIPTION
Adding missing dependencies to avoid CDI errors.

@tomasdavidorg @cristianonicolai could you please take a look?

This is part of an ensemble, please merge with:
https://github.com/kiegroup/drools/pull/2277
https://github.com/kiegroup/kie-wb-common/pull/2525
https://github.com/kiegroup/jbpm-wb/pull/1316
https://github.com/kiegroup/jbpm-designer/pull/842
https://github.com/kiegroup/kie-wb-distributions/pull/898