### PR TITLE
Workbench REST tests: Remove admin role from rest users

### DIFF
--- a/business-central-tests/pom.xml
+++ b/business-central-tests/pom.xml
@@ -128,7 +128,7 @@
               <properties>
                 <cargo.servlet.port>${container.port}</cargo.servlet.port>
                 <cargo.servlet.users>
-                  admin:admin1234;:admin|restAll:restAll1234;:admin,rest-all|restProject:restProject1234;:admin,rest-project|noRest:noRest1234;:admin
+                  admin:admin1234;:admin|restAll:restAll1234;:rest-all|restProject:restProject1234;:rest-project|noRest:noRest1234;:guest
                 </cargo.servlet.users>
               </properties>
             </configuration>


### PR DESCRIPTION
According [documentation](https://access.redhat.com/documentation/en-us/red_hat_process_automation_manager/7.3/html-single/installing_and_configuring_red_hat_process_automation_manager_on_red_hat_jboss_eap_7.2/index#roles-users-con) user with rest-all role can access Business Central REST capabilities.
This PR is also reproducer for [RHPAM-2081](https://issues.jboss.org/browse/RHPAM-2081) and failing of kie-wb-rest-tests is expected.