### PR TITLE
DROOLS-4049: PMML files are not listed in Library only in Project Explorer

### DIFF
--- a/business-central-parent/business-central-webapp/pom.xml
+++ b/business-central-parent/business-central-webapp/pom.xml
@@ -861,6 +861,11 @@
       <groupId>org.drools</groupId>
       <artifactId>drools-wb-workitems-editor-backend</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.drools</groupId>
+      <artifactId>drools-wb-pmml-text-editor-client</artifactId>
+      <scope>provided</scope>
+    </dependency>
 
     <!-- Models for OptaPlanner Workbench Screens -->
     <dependency>
@@ -1566,6 +1571,10 @@
     <dependency>
       <groupId>org.drools</groupId>
       <artifactId>drools-wb-dsl-text-editor-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.drools</groupId>
+      <artifactId>drools-wb-pmml-text-editor-api</artifactId>
     </dependency>
 
     <!-- org.kie.dmn -->
@@ -2452,6 +2461,8 @@
             <compileSourcesArtifact>org.drools:drools-wb-scenario-simulation-editor-api</compileSourcesArtifact>
             <compileSourcesArtifact>org.drools:drools-wb-scenario-simulation-editor-client</compileSourcesArtifact>
             <compileSourcesArtifact>org.drools:drools-scenario-simulation-api</compileSourcesArtifact>
+            <compileSourcesArtifact>org.drools:drools-wb-pmml-text-editor-api</compileSourcesArtifact>
+            <compileSourcesArtifact>org.drools:drools-wb-pmml-text-editor-client</compileSourcesArtifact>
 
             <!-- DMN Editor -->
             <compileSourcesArtifact>org.kie.workbench:kie-wb-common-dmn-api</compileSourcesArtifact>

--- a/business-central-parent/business-central-webapp/src/main/resources/org/kie/bc/KIEWebapp.gwt.xml
+++ b/business-central-parent/business-central-webapp/src/main/resources/org/kie/bc/KIEWebapp.gwt.xml
@@ -107,6 +107,7 @@
   <inherits name="org.drools.workbench.screens.scorecardxls.DroolsWorkbenchScoreCardXLSEditorClient"/>
   <inherits name="org.drools.workbench.screens.testscenario.DroolsWorkbenchTestScenarioEditorClient"/>
   <inherits name='org.drools.workbench.screens.scenariosimulation.DroolsWorkbenchScenarioSimulationEditorClient'/>
+  <inherits name="org.drools.workbench.screens.pmmltext.DroolsWorkbenchPMMLTextEditorClient"/>
 
   <!-- DMN Editor -->
   <inherits name="org.kie.workbench.common.dmn.project.DMNProjectClient"/>


### PR DESCRIPTION
See https://issues.jboss.org/browse/DROOLS-4049

Further to [this](https://github.com/kiegroup/drools-wb/pull/1144) adding PMML to Business Central.

IDK why dependencies are scattered around the `pom` (i.e. `-api` are not grouped with `-client`/`-backend`) I just followed positioning of the existing artifacts when adding the new PMML ones.