### PR TITLE
RHPAM-2101: BC Monitoring fails to start a new process in an unmanaged immutable kieserver

### DIFF
--- a/business-central-parent/business-central-webapp/src/main/resources/org/kie/bc/KIEWebapp.gwt.xml
+++ b/business-central-parent/business-central-webapp/src/main/resources/org/kie/bc/KIEWebapp.gwt.xml
@@ -135,9 +135,6 @@
 
   <inherits name="com.google.gwt.xml.XML"/>
 
-  <!-- Form modeler.-->
-  <inherits name="org.kie.workbench.common.forms.dynamic.DynamicFormsClient"/>
-
   <!-- Stunner. -->
   <inherits name="org.kie.workbench.common.stunner.project.StunnerProjectClient"/>
   <inherits name="org.kie.workbench.common.stunner.bpmn.StunnerBpmnProjectClient"/>

--- a/business-central-parent/business-monitoring-webapp/pom.xml
+++ b/business-central-parent/business-monitoring-webapp/pom.xml
@@ -1596,6 +1596,7 @@
             <compileSourcesArtifact>org.kie.workbench.forms:kie-wb-common-forms-crud-component</compileSourcesArtifact>
             <compileSourcesArtifact>org.kie.workbench.forms:kie-wb-common-dynamic-forms-api</compileSourcesArtifact>
             <compileSourcesArtifact>org.kie.workbench.forms:kie-wb-common-dynamic-forms-client</compileSourcesArtifact>
+            <compileSourcesArtifact>org.kie.workbench.forms:kie-wb-common-forms-data-modeller-integration-api</compileSourcesArtifact>
             <compileSourcesArtifact>org.kie.workbench.forms:kie-wb-common-forms-editor-api</compileSourcesArtifact>
             <compileSourcesArtifact>org.kie.workbench.forms:kie-wb-common-forms-editor-client</compileSourcesArtifact>
             <compileSourcesArtifact>org.kie.workbench.forms:kie-wb-common-forms-jbpm-integration-api</compileSourcesArtifact>

--- a/business-central-parent/business-monitoring-webapp/src/main/resources/org/kie/bc/KIEWebapp.gwt.xml
+++ b/business-central-parent/business-monitoring-webapp/src/main/resources/org/kie/bc/KIEWebapp.gwt.xml
@@ -69,6 +69,7 @@
   <inherits name="org.uberfire.ext.security.management.UberfireSecurityManagementWorkbench"/>
 
   <!-- Forms Engine -->
+  <inherits name="org.kie.workbench.common.forms.data.modeller.FormDataModellerIntegrationAPI"/>
   <inherits name="org.kie.workbench.common.forms.dynamic.DynamicFormsClient"/>
   <inherits name="org.kie.workbench.common.forms.jbpm.FormJBPMIntegrationClient"/>
 


### PR DESCRIPTION
Adding missing config for forms engine on monitoring webapp. Additionaly removed duplicated gwt module on BC.

@tomasdavidorg @cristianonicolai @sutaakar could you please take a look?