### PR TITLE
[AF-1792]  Migration of space information from system.git to config.git + HA improvements

### DIFF
--- a/business-central-tests/business-central-tests-rest/src/test/java/org/kie/wb/test/rest/AccessRestTestBase.java
+++ b/business-central-tests/business-central-tests-rest/src/test/java/org/kie/wb/test/rest/AccessRestTestBase.java
@@ -40,7 +40,8 @@ public abstract class AccessRestTestBase extends RestTestBase {
     public AccessRestTestBase(User user) {
         this.user = user;
 
-        roleClient = RestWorkbenchClient.createWorkbenchClient(URL, user.getUserName(), user.getPassword());
+        int fiveMinutes = 5 * 60;
+        roleClient = RestWorkbenchClient.createWorkbenchClient(URL, user.getUserName(), user.getPassword(), fiveMinutes, fiveMinutes, fiveMinutes);
     }
 
     private void assertOperationDoesNotFail(Operation operation) {
@@ -70,7 +71,7 @@ public abstract class AccessRestTestBase extends RestTestBase {
 
     @FunctionalInterface
     protected interface Operation {
+
         Object execute();
     }
-
 }

--- a/business-central-tests/business-central-tests-rest/src/test/java/org/kie/wb/test/rest/RestTestBase.java
+++ b/business-central-tests/business-central-tests-rest/src/test/java/org/kie/wb/test/rest/RestTestBase.java
@@ -20,6 +20,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 import java.util.Collection;
+import java.util.Random;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.time.StopWatch;
@@ -134,6 +135,18 @@ public abstract class RestTestBase {
                 log.debug("Deleting space '{}' took {} ms", space.getName(), stopWatch.getTime());
             }
         });
+    }
+
+    protected static String getRandomString() {
+        Random random = new Random();
+        String dic = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+        int len = 5;
+        String result = "";
+        for (int i = 0; i < len; i++) {
+            int index = random.nextInt(dic.length());
+            result += dic.charAt(index);
+        }
+        return result;
     }
 
     protected static String getLocalGitRepositoryUrl() {

--- a/business-central-tests/business-central-tests-rest/src/test/java/org/kie/wb/test/rest/security/JobAccessIntegrationTest.java
+++ b/business-central-tests/business-central-tests-rest/src/test/java/org/kie/wb/test/rest/security/JobAccessIntegrationTest.java
@@ -17,6 +17,7 @@
 package org.kie.wb.test.rest.security;
 
 import org.guvnor.rest.client.JobRequest;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -26,22 +27,29 @@ import org.kie.wb.test.rest.User;
 @RunWith(Parameterized.class)
 public class JobAccessIntegrationTest extends AccessRestTestBase {
 
+    private static String randomString;
+
     public JobAccessIntegrationTest(User user) {
         super(user);
     }
 
+    @BeforeClass
+    public static void beforeClass() {
+        randomString = getRandomString();
+    }
+
+
     @Test
     public void testGetJob() {
-        JobRequest jobRequest = createSpace("getSpaceWith" + user.getUserName());
+        JobRequest jobRequest = createSpace("getSpaceWith" + user.getUserName() + "-" + randomString);
 
         assertOperation(() -> roleClient.getJob(jobRequest.getJobId()));
     }
 
     @Test
     public void testDeleteJob() {
-        JobRequest jobRequest = createSpace("deleteSpaceWith" + user.getUserName());
+        JobRequest jobRequest = createSpace("deleteSpaceWith" + user.getUserName() + "-" + randomString);
 
         assertOperation(() -> roleClient.deleteJob(jobRequest.getJobId()));
     }
-
 }


### PR DESCRIPTION
# AF-1792

## Description

Several things happen in this PR that can't be split in several commits:

### Migration from system.git to config.git

All the information about spaces and repositories used to live in system.git project. That project makes that every change that was need to be done locks repository for all users. 
Now, all the information about each space is stored inside config.git in every space. So lock will happen only for that space and not for the whole file system. Also migration tool was modified to include previous changes.

### Logical Deletion

When you delete a Space or Repository, they are marked to be deleted. User will continue working as it was used to. Nothing from user perspectiva but they way that deleted spaces are shown. 
* A deleted Repository disappear from Library View and is marked to be deleted with a flag in config.git
* A deleted Space doesn't disappear from Spaces View but users can't get into that Space. In the UI the space is marked to be deleted. Also is marked to be deleted with a flag in config.git.

### Physical Deletion

Every one minute a FileSystemDeleteWorker runs to delete all the repositories and spaces that are marked to be deleted. This runs in all nodes, but only one will be able to execute those operations.

### HA Improvements

Many events where added to improve HA experience. Also visual improvements to show correct assets/spaces/repositories/contributors counters and deleted spaces right identification.

### RHSSO

RHSSO configuration was included to let BC consume contributors from SSO List.

## Collaborators

* Paulo Rego
* Pere Fernandez Pere
* Eder Ignatowicz
* Adriel Paredes

## PRs related

* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/970
* https://github.com/kiegroup/appformer/pull/715
* https://github.com/kiegroup/kie-wb-common/pull/2692
* https://github.com/kiegroup/jbpm-wb/pull/1362
* https://github.com/kiegroup/kie-wb-distributions/pull/936

