### PR TITLE
JBPM-8124: Remove legacy process designer from the asset list

### DIFF
--- a/business-central-parent/business-central-webapp/src/main/resources/security-policy.properties
+++ b/business-central-parent/business-central-webapp/src/main/resources/security-policy.properties
@@ -58,6 +58,7 @@ default.permission.editor.read.GuidedDecisionTreeEditorPresenter=true
 default.permission.editor.read.GuidedScoreCardEditor=true
 default.permission.editor.read.ScoreCardXLSEditor=true
 default.permission.editor.read.BPMNDiagramEditor=true
+default.permission.editor.read.jbpm.designer=false
 
 default.permission.globalExperimentalFeatures.edit=true
 

--- a/business-central-parent/business-central-webapp/src/main/resources/security-policy.properties
+++ b/business-central-parent/business-central-webapp/src/main/resources/security-policy.properties
@@ -57,7 +57,6 @@ default.permission.perspective.read.ProvisioningManagementPerspective=true
 default.permission.editor.read.GuidedDecisionTreeEditorPresenter=true
 default.permission.editor.read.GuidedScoreCardEditor=true
 default.permission.editor.read.ScoreCardXLSEditor=true
-default.permission.editor.read.BPMNDiagramEditor=true
 default.permission.editor.read.jbpm.designer=false
 
 default.permission.globalExperimentalFeatures.edit=true

--- a/business-central-parent/business-central-webapp/src/main/resources/security-policy.properties
+++ b/business-central-parent/business-central-webapp/src/main/resources/security-policy.properties
@@ -57,6 +57,7 @@ default.permission.perspective.read.ProvisioningManagementPerspective=true
 default.permission.editor.read.GuidedDecisionTreeEditorPresenter=true
 default.permission.editor.read.GuidedScoreCardEditor=true
 default.permission.editor.read.ScoreCardXLSEditor=true
+default.permission.editor.read.BPMNDiagramEditor=true
 default.permission.editor.read.jbpm.designer=false
 
 default.permission.globalExperimentalFeatures.edit=true


### PR DESCRIPTION
@romartin can you check this PR? This change sets the Legacy designer Editor Permissions to false, meaning it will not be visible by fefault. This relates to 2 other PRs( https://github.com/kiegroup/jbpm-designer/pull/858, https://github.com/kiegroup/kie-wb-common/pull/2798)