### PR TITLE
BAQE-982: Upgrade Gecko Driver Version

### DIFF
--- a/business-central-tests/business-central-tests-gui/src/test/filtered-resources/arquillian.xml
+++ b/business-central-tests/business-central-tests-gui/src/test/filtered-resources/arquillian.xml
@@ -21,7 +21,7 @@ limitations under the License.
     <property name="waitModelInterval">15</property>
     <property name="firefox_binary">${webdriver.firefox.bin}</property>
     <property name="firefoxArguments">-headless</property>
-    <property name="firefoxDriverVersion">0.22.0</property>
-    <property name="firefoxDriverUrl">https://github.com/mozilla/geckodriver/releases/download/v0.22.0/geckodriver-v0.22.0-linux64.tar.gz</property>
+    <property name="firefoxDriverVersion">0.24.0</property>
+    <property name="firefoxDriverUrl">https://github.com/mozilla/geckodriver/releases/download/v0.24.0/geckodriver-v0.24.0-linux64.tar.gz</property>
   </extension>
 </arquillian>


### PR DESCRIPTION
An attempt to stabilize failing community selenium tests.