### PR TITLE
Use rerunFailingTestsCount for BC integration test

### DIFF
--- a/business-central-tests/business-central-tests-gui/pom.xml
+++ b/business-central-tests/business-central-tests-gui/pom.xml
@@ -191,6 +191,7 @@
             <selenium.homepage.loading.timeout.seconds>${selenium.homepage.loading.timeout.seconds}</selenium.homepage.loading.timeout.seconds>
             <webdriver.firefox.logfile>${project.build.directory}/firefox-webdriver.log</webdriver.firefox.logfile>
           </systemPropertyVariables>
+          <rerunFailingTestsCount>2</rerunFailingTestsCount>      
         </configuration>
       </plugin>
     </plugins>

--- a/business-central-tests/pom.xml
+++ b/business-central-tests/pom.xml
@@ -161,7 +161,6 @@
             </systemPropertyVariables>
             <failIfNoTests>false</failIfNoTests>
             <argLine>-Xmx1024m -Dfile.encoding=UTF-8</argLine>
-            <rerunFailingTestsCount>2</rerunFailingTestsCount>
           </configuration>
           <executions>
             <execution>

--- a/business-central-tests/pom.xml
+++ b/business-central-tests/pom.xml
@@ -161,6 +161,7 @@
             </systemPropertyVariables>
             <failIfNoTests>false</failIfNoTests>
             <argLine>-Xmx1024m -Dfile.encoding=UTF-8</argLine>
+            <rerunFailingTestsCount>2</rerunFailingTestsCount>
           </configuration>
           <executions>
             <execution>


### PR DESCRIPTION
@tomasdavidorg @jomarko Adding it here as I see the selenium tests failing in common fashion, this is a test to see if it helps.