### PR TITLE
[AF-2332] Add Branch support to Business Central REST API

### DIFF
--- a/business-central-tests/business-central-tests-rest/src/main/java/org/kie/wb/test/rest/client/RestWorkbenchClient.java
+++ b/business-central-tests/business-central-tests-rest/src/main/java/org/kie/wb/test/rest/client/RestWorkbenchClient.java
@@ -283,11 +283,29 @@ public class RestWorkbenchClient implements WorkbenchClient {
                 .request().post(createEntity(""), requestType);
     }
 
+    private <T extends JobRequest> T postMavenRequest(String spaceName, String projectName, String branchName, String phase, Class<T> requestType) {
+        return target.path("spaces/{spaceName}/projects/{projectName}/branches/{branchName}/maven/{phase}")
+                .resolveTemplate("spaceName", spaceName)
+                .resolveTemplate("projectName", projectName)
+                .resolveTemplate("branchName", branchName)
+                .resolveTemplate("phase", phase)
+                .request().post(createEntity(""), requestType);
+    }
+
     @Override
     public CompileProjectRequest compileProject(String spaceName, String projectName) {
         log.info("Compiling project '{}' from space '{}'", projectName, spaceName);
 
         CompileProjectRequest request = postMavenRequest(spaceName, projectName, "compile", CompileProjectRequest.class);
+
+        return waitUntilJobFinished(request, projectJobTimeoutSeconds);
+    }
+
+    @Override
+    public CompileProjectRequest compileProject(String spaceName, String projectName, String branchName) {
+        log.info("Compiling project '{}' branch '{}' from space '{}'", projectName, branchName, spaceName);
+
+        CompileProjectRequest request = postMavenRequest(spaceName, projectName, branchName, "compile", CompileProjectRequest.class);
 
         return waitUntilJobFinished(request, projectJobTimeoutSeconds);
     }
@@ -302,6 +320,15 @@ public class RestWorkbenchClient implements WorkbenchClient {
     }
 
     @Override
+    public InstallProjectRequest installProject(String spaceName, String projectName, String branchName) {
+        log.info("Installing project '{}' branch '{}' from space '{}'", projectName, branchName, spaceName);
+
+        InstallProjectRequest request = postMavenRequest(spaceName, projectName, branchName, "install", InstallProjectRequest.class);
+
+        return waitUntilJobFinished(request, projectJobTimeoutSeconds);
+    }
+
+    @Override
     public TestProjectRequest testProject(String spaceName, String projectName) {
         log.info("Testing project '{}' from space '{}'", projectName, spaceName);
 
@@ -311,10 +338,28 @@ public class RestWorkbenchClient implements WorkbenchClient {
     }
 
     @Override
+    public TestProjectRequest testProject(String spaceName, String projectName, String branchName) {
+        log.info("Testing project '{}' branch '{}' from space '{}'", projectName, branchName, spaceName);
+
+        TestProjectRequest request = postMavenRequest(spaceName, projectName, branchName, "test", TestProjectRequest.class);
+
+        return waitUntilJobFinished(request, projectJobTimeoutSeconds);
+    }
+
+    @Override
     public DeployProjectRequest deployProject(String spaceName, String projectName) {
         log.info("Deploying project '{}' from space '{}'", projectName, spaceName);
 
         DeployProjectRequest request = postMavenRequest(spaceName, projectName, "deploy", DeployProjectRequest.class);
+
+        return waitUntilJobFinished(request, projectJobTimeoutSeconds);
+    }
+
+    @Override
+    public DeployProjectRequest deployProject(String spaceName, String projectName, String branchName) {
+        log.info("Deploying project '{}' branch '{}' from space '{}'", projectName, branchName, spaceName);
+
+        DeployProjectRequest request = postMavenRequest(spaceName, projectName, branchName, "deploy", DeployProjectRequest.class);
 
         return waitUntilJobFinished(request, projectJobTimeoutSeconds);
     }

--- a/business-central-tests/business-central-tests-rest/src/main/java/org/kie/wb/test/rest/client/WorkbenchClient.java
+++ b/business-central-tests/business-central-tests-rest/src/main/java/org/kie/wb/test/rest/client/WorkbenchClient.java
@@ -136,9 +136,19 @@ public interface WorkbenchClient {
     CompileProjectRequest compileProject(String spaceName, String projectName);
 
     /**
+     * [POST] /spaces/{spaceName}/projects/{projectName}/branches/{branchName}/maven/compile
+     */
+    CompileProjectRequest compileProject(String spaceName, String projectName, String branchName);
+
+    /**
      * [POST] /spaces/{spaceName}/projects/{projectName}/maven/install
      */
     InstallProjectRequest installProject(String spaceName, String projectName);
+
+    /**
+     * [POST] /spaces/{spaceName}/projects/{projectName}/branches/{branchName}/maven/install
+     */
+    InstallProjectRequest installProject(String spaceName, String projectName, String branchName);
 
     /**
      * [POST] /spaces/{spaceName}/projects/{projectName}/maven/test
@@ -146,9 +156,19 @@ public interface WorkbenchClient {
     TestProjectRequest testProject(String spaceName, String projectName);
 
     /**
+     * [POST] /spaces/{spaceName}/projects/{projectName}/branches/{branchName}/maven/test
+     */
+    TestProjectRequest testProject(String spaceName, String projectName, String branchName);
+
+    /**
      * [POST] /spaces/{spaceName}/projects/{projectName}/maven/deploy
      */
     DeployProjectRequest deployProject(String spaceName, String projectName);
+
+    /**
+     * [POST] /spaces/{spaceName}/projects/{projectName}/branches/{branchName}/maven/deploy
+     */
+    DeployProjectRequest deployProject(String spaceName, String projectName, String branchName);
 
     /**
      * [GET] /spacesScreen/spaces

--- a/business-central-tests/business-central-tests-rest/src/test/java/org/kie/wb/test/rest/functional/ProjectIntegrationTest.java
+++ b/business-central-tests/business-central-tests-rest/src/test/java/org/kie/wb/test/rest/functional/ProjectIntegrationTest.java
@@ -138,6 +138,17 @@ public class ProjectIntegrationTest extends RestTestBase {
     }
 
     @Test
+    public void testCompileProjectMasterBranch() {
+        String name = "projectToBeCompiled";
+        createProject(name, null, GROUP_ID, VERSION);
+
+        CompileProjectRequest request = client.compileProject(SPACE, name, "master");
+        assertThat(request.getSpaceName()).isEqualTo(SPACE);
+        assertThat(request.getProjectName()).isEqualTo(name);
+        assertThat(request.getBranchName()).isEqualTo("master");
+    }
+
+    @Test
     public void testTestProject() {
         String name = "projectToBeTested";
         createProject(name, null, GROUP_ID, VERSION);
@@ -148,6 +159,17 @@ public class ProjectIntegrationTest extends RestTestBase {
     }
 
     @Test
+    public void testTestProjectMasterBranch() {
+        String name = "projectToBeTested";
+        createProject(name, null, GROUP_ID, VERSION);
+
+        TestProjectRequest request = client.testProject(SPACE, name, "master");
+        assertThat(request.getSpaceName()).isEqualTo(SPACE);
+        assertThat(request.getProjectName()).isEqualTo(name);
+        assertThat(request.getBranchName()).isEqualTo("master");
+    }
+
+    @Test
     public void testInstallProject() {
         String name = "projectToBeInstalled" + Math.random();
         createProject(name, null, GROUP_ID, VERSION);
@@ -155,6 +177,17 @@ public class ProjectIntegrationTest extends RestTestBase {
         InstallProjectRequest request = client.installProject(SPACE, name);
         assertThat(request.getSpaceName()).isEqualTo(SPACE);
         assertThat(request.getProjectName()).isEqualTo(name);
+    }
+
+    @Test
+    public void testInstallProjectMasterBranch() {
+        String name = "projectToBeInstalled" + Math.random();
+        createProject(name, null, GROUP_ID, VERSION);
+
+        InstallProjectRequest request = client.installProject(SPACE, name, "master");
+        assertThat(request.getSpaceName()).isEqualTo(SPACE);
+        assertThat(request.getProjectName()).isEqualTo(name);
+        assertThat(request.getBranchName()).isEqualTo("master");
     }
 
     @Test
@@ -195,6 +228,17 @@ public class ProjectIntegrationTest extends RestTestBase {
         DeployProjectRequest request = client.deployProject(SPACE, name);
         assertThat(request.getSpaceName()).isEqualTo(SPACE);
         assertThat(request.getProjectName()).isEqualTo(name);
+    }
+
+    @Test
+    public void testDeployProjectMasterBranch() {
+        String name = "projectToBeDeployed" + Math.random();
+        createProject(name, null, GROUP_ID, VERSION);
+
+        DeployProjectRequest request = client.deployProject(SPACE, name, "master");
+        assertThat(request.getSpaceName()).isEqualTo(SPACE);
+        assertThat(request.getProjectName()).isEqualTo(name);
+        assertThat(request.getBranchName()).isEqualTo("master");
     }
 
     @Test


### PR DESCRIPTION
Adding tests cases for [AF-2332] Add Branch support to Business Central REST API
See https://github.com/kiegroup/appformer/pull/841

Limitations:
* Could not test `null` branch since RESTEasy does not allow null parameters
* Could not test additional branches since there are not REST endpoints to create branches