### PR TITLE
RHPAM-2611 errai-bus dependency removed from business-monitoring. Branch 7.30.x

### DIFF
--- a/business-central-parent/business-monitoring-webapp/pom.xml
+++ b/business-central-parent/business-monitoring-webapp/pom.xml
@@ -552,10 +552,6 @@
     <!-- Errai Core -->
     <dependency>
       <groupId>org.jboss.errai</groupId>
-      <artifactId>errai-bus</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.jboss.errai</groupId>
       <artifactId>errai-ioc</artifactId>
     </dependency>
     <dependency>


### PR DESCRIPTION
RHPAM-2611