### PR TITLE
BXMSPROD-621 uberfire-metadata-backend-elasticsearch dependency removed from business-monitoring. Branch master

### DIFF
--- a/business-central-parent/business-central-distribution-wars/business-monitoring/pom.xml
+++ b/business-central-parent/business-central-distribution-wars/business-monitoring/pom.xml
@@ -27,6 +27,23 @@
       <artifactId>business-monitoring-webapp</artifactId>
       <type>war</type>
     </dependency>
+
+    <dependency>
+      <groupId>org.kie</groupId>
+      <artifactId>business-monitoring-webapp</artifactId>
+      <classifier>thorntail</classifier>
+      <exclusions>
+        <exclusion>
+          <groupId>org.yaml</groupId>
+          <artifactId>snakeyaml</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>xml-apis</groupId>
+          <artifactId>xml-apis-ext</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
     <dependency>
       <groupId>org.kie</groupId>
       <artifactId>kie-swagger-ui</artifactId>

--- a/business-central-parent/business-central-webapp/pom.xml
+++ b/business-central-parent/business-central-webapp/pom.xml
@@ -1398,20 +1398,6 @@
     </dependency>
     <dependency>
       <groupId>org.uberfire</groupId>
-      <artifactId>uberfire-metadata-backend-elasticsearch</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>jakarta-regexp</groupId>
-          <artifactId>jakarta-regexp</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>io.netty</groupId>
-          <artifactId>netty</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>org.uberfire</groupId>
       <artifactId>uberfire-metadata-backend-infinispan</artifactId>
       <exclusions>
         <exclusion>

--- a/business-central-parent/business-central-webapp/pom.xml
+++ b/business-central-parent/business-central-webapp/pom.xml
@@ -1404,6 +1404,10 @@
           <groupId>jakarta-regexp</groupId>
           <artifactId>jakarta-regexp</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>

--- a/business-central-parent/business-monitoring-webapp/pom.xml
+++ b/business-central-parent/business-monitoring-webapp/pom.xml
@@ -552,6 +552,20 @@
     <!-- Errai Core -->
     <dependency>
       <groupId>org.jboss.errai</groupId>
+      <artifactId>errai-bus</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-handler</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-codec-http</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.errai</groupId>
       <artifactId>errai-ioc</artifactId>
     </dependency>
     <dependency>

--- a/business-central-parent/business-monitoring-webapp/pom.xml
+++ b/business-central-parent/business-monitoring-webapp/pom.xml
@@ -552,10 +552,6 @@
     <!-- Errai Core -->
     <dependency>
       <groupId>org.jboss.errai</groupId>
-      <artifactId>errai-bus</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.jboss.errai</groupId>
       <artifactId>errai-ioc</artifactId>
     </dependency>
     <dependency>

--- a/business-central-parent/business-monitoring-webapp/pom.xml
+++ b/business-central-parent/business-monitoring-webapp/pom.xml
@@ -829,6 +829,10 @@
           <groupId>jakarta-regexp</groupId>
           <artifactId>jakarta-regexp</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>

--- a/business-central-parent/business-monitoring-webapp/pom.xml
+++ b/business-central-parent/business-monitoring-webapp/pom.xml
@@ -823,20 +823,6 @@
     </dependency>
     <dependency>
       <groupId>org.uberfire</groupId>
-      <artifactId>uberfire-metadata-backend-elasticsearch</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>jakarta-regexp</groupId>
-          <artifactId>jakarta-regexp</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>io.netty</groupId>
-          <artifactId>netty</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>org.uberfire</groupId>
       <artifactId>uberfire-metadata-backend-infinispan</artifactId>
       <exclusions>
         <exclusion>


### PR DESCRIPTION
BXMSPROD-621
io.netty:netty exclusion added to org.uberfire:uberfire-metadata-backend-elasticsearch