### PR TITLE
BXMSPROD-598 filterWebInfLib property added to thorntail maven plugin

### DIFF
--- a/business-central-parent/business-central-webapp/pom.xml
+++ b/business-central-parent/business-central-webapp/pom.xml
@@ -2781,7 +2781,10 @@
       </plugin>
       <plugin>
         <groupId>io.thorntail</groupId>
-        <artifactId>thorntail-maven-plugin</artifactId>
+	<artifactId>thorntail-maven-plugin</artifactId>
+        <configuration>
+          <filterWebInfLib>uberjar-only</filterWebInfLib>
+        </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/business-central-parent/business-central-webapp/pom.xml
+++ b/business-central-parent/business-central-webapp/pom.xml
@@ -2781,7 +2781,7 @@
       </plugin>
       <plugin>
         <groupId>io.thorntail</groupId>
-	<artifactId>thorntail-maven-plugin</artifactId>
+        <artifactId>thorntail-maven-plugin</artifactId>
         <configuration>
           <filterWebInfLib>uberjar-only</filterWebInfLib>
         </configuration>

--- a/business-central-parent/business-monitoring-webapp/pom.xml
+++ b/business-central-parent/business-monitoring-webapp/pom.xml
@@ -1629,6 +1629,9 @@
       <plugin>
         <groupId>io.thorntail</groupId>
         <artifactId>thorntail-maven-plugin</artifactId>
+        <configuration>
+          <filterWebInfLib>uberjar-only</filterWebInfLib>
+        </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
https://issues.redhat.com/browse/BXMSPROD-598

filterWebInfLib property added with the value 'uberjar-only' to thorntail maven plugin to the business-monitoring-webapp and business-central-webapp