### PR TITLE
[KIECLOUD-256] Revert and disable nio2.k8s impl due to readiness of the blocking issue [AF-2253]

### DIFF
--- a/business-central-parent/business-monitoring-webapp/src/main/resources/META-INF/services/org.uberfire.java.nio.file.spi.FileSystemProvider
+++ b/business-central-parent/business-monitoring-webapp/src/main/resources/META-INF/services/org.uberfire.java.nio.file.spi.FileSystemProvider
@@ -1,69 +1,5 @@
 #
-# Copyright 2017 Red Hat, Inc. and/or its affiliates.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#       http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
-
-#
-# Copyright 2017 Red Hat, Inc. and/or its affiliates.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#       http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
-
-#
-# Copyright 2017 Red Hat, Inc. and/or its affiliates.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#       http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
-
-#
-# Copyright 2017 Red Hat, Inc. and/or its affiliates.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#       http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
-
-#
-# Copyright 2017 Red Hat, Inc. and/or its affiliates.
+# Copyright 2020 Red Hat, Inc. and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -79,6 +15,6 @@
 #
 
 org.uberfire.java.nio.fs.jgit.JGitFileSystemProvider  # file system provider, also default (1st)
-org.uberfire.java.nio.fs.k8s.K8SFileSystemProvider    # can be set as default at runtime by system property: org.kie.workbench.controller.openshift.enabled
+# org.uberfire.java.nio.fs.k8s.K8SFileSystemProvider    # can be set as default at runtime by system property: org.kie.workbench.controller.openshift.enabled
 org.uberfire.java.nio.fs.file.SimpleFileSystemProvider
 # org.kie.commons.java.nio.fs.eclipse.EclipseFileSystemProvider  # eclipse provider


### PR DESCRIPTION
Can only re-enable nio2.k8s file system implementation along with or after PRs related to AF-2253 being merged.

Related JIRAs
https://issues.redhat.com/projects/AF/issues/AF-2253

Signed-off-by: Evan Zhang <evan.zhang@redhat.com>