### PR TITLE
AF-2524: Upgrade business central tests to use wildfly18

### DIFF
--- a/business-central-tests/pom.xml
+++ b/business-central-tests/pom.xml
@@ -236,7 +236,7 @@
         </dependency>
       </dependencies>
       <properties>
-        <cargo.container.id>wildfly14x</cargo.container.id>
+        <cargo.container.id>wildfly18x</cargo.container.id>
       </properties>
       <build>
         <pluginManagement>
@@ -345,8 +345,8 @@
               <configuration>
                 <container>
                   <type>installed</type>
-                  <!-- WildFly ~= EAP 7, so just reuse the wildfly14x containerId -->
-                  <containerId>wildfly14x</containerId>
+                  <!-- WildFly ~= EAP 7, so just reuse the wildfly18x containerId -->
+                  <containerId>wildfly18x</containerId>
                   <type>installed</type>
                   <zipUrlInstaller>
                     <url>${eap7.download.url}</url>


### PR DESCRIPTION
Wildfly container was recently upgraded to version 18 across kiegroup codebase. We need to upgrade also version for tests.

For more details see:
- https://issues.redhat.com/browse/AF-2524
- https://issues.redhat.com/browse/JBPM-9044