### PR TITLE
RHPAM-2985 : Removed Jboss EAP plateform specific dependancies and added to container

### DIFF
--- a/business-central-parent/business-central-distribution-wars/business-central/pom.xml
+++ b/business-central-parent/business-central-distribution-wars/business-central/pom.xml
@@ -61,8 +61,8 @@
           <artifactId>xml-apis-ext</artifactId>
        </exclusion>
        <exclusion>
-            <groupId>org.jboss.modules</groupId>
-            <artifactId>jboss-modules</artifactId>
+          <groupId>org.jboss.modules</groupId>
+          <artifactId>jboss-modules</artifactId>
         </exclusion>	       
       </exclusions>
     </dependency>

--- a/business-central-parent/business-central-distribution-wars/business-monitoring/pom.xml
+++ b/business-central-parent/business-central-distribution-wars/business-monitoring/pom.xml
@@ -41,6 +41,10 @@
           <groupId>xml-apis</groupId>
           <artifactId>xml-apis-ext</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.jboss.modules</groupId>
+          <artifactId>jboss-modules</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
 

--- a/business-central-parent/business-central-webapp-common/src/main/webapp/META-INF/jboss-deployment-structure.xml
+++ b/business-central-parent/business-central-webapp-common/src/main/webapp/META-INF/jboss-deployment-structure.xml
@@ -28,19 +28,6 @@
       <!-- JMS API required by kie-server-client as there is an runtime API dependency
            (even though the JMS is not being used for the communication itself). -->
       <module name="javax.jms.api"/>
-
-      <!-- ******************************************************************************************** -->
-      <!-- EXCEPTIONS - private/unsupported modules that can not be directly added into the WEB-INF/lib -->
-      <!-- ******************************************************************************************** -->
-
-      <!-- WildFly/EAP security management provider's client dependencies.
-           These modules provide libraries for the properties realm management, required if using the concrete
-           WildFly/EAP provider for the user system management, as this webapp does by default. -->
-      <module name="org.jboss.as.controller-client"/>
-      <module name="org.jboss.as.domain-management"/>
-      <module name="org.jboss.msc"/>
-      <module name="org.jboss.dmr"/>
-      
     </dependencies>
   </deployment>
 </jboss-deployment-structure>

--- a/business-central-parent/business-central-webapp/pom.xml
+++ b/business-central-parent/business-central-webapp/pom.xml
@@ -1782,6 +1782,16 @@
       <scope>runtime</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.wildfly.core</groupId>
+      <artifactId>wildfly-domain-management</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jboss.msc</groupId>
+      <artifactId>jboss-msc</artifactId>
+    </dependency>
+
     <!-- UF Security management provider for Keycloak.  -->
     <dependency>
       <groupId>org.uberfire</groupId>

--- a/business-central-parent/business-monitoring-webapp/pom.xml
+++ b/business-central-parent/business-monitoring-webapp/pom.xml
@@ -1167,6 +1167,16 @@
       <scope>runtime</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.wildfly.core</groupId>
+      <artifactId>wildfly-domain-management</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jboss.msc</groupId>
+      <artifactId>jboss-msc</artifactId>
+    </dependency>
+
     <!-- Validation -->
     <dependency>
       <groupId>org.jboss.errai</groupId>


### PR DESCRIPTION
- Removed platform specific dependencies from jboss-deployment-structure.xml and added them to container.
- These dependencies were conflicting  in wildfly 18 and wildfly 14.

Related or Merge with : https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1362