### PR TITLE
excluded org.jboss.modules because of duplicated classes

### DIFF
--- a/business-central-parent/business-central-distribution-wars/business-central/pom.xml
+++ b/business-central-parent/business-central-distribution-wars/business-central/pom.xml
@@ -59,7 +59,11 @@
         <exclusion>
           <groupId>xml-apis</groupId>
           <artifactId>xml-apis-ext</artifactId>
-        </exclusion>
+       </exclusion>
+       <exclusion>
+            <groupId>org.jboss.modules</groupId>
+            <artifactId>jboss-modules</artifactId>
+        </exclusion>	       
       </exclusions>
     </dependency>
   </dependencies>


### PR DESCRIPTION
(cherry picked from commit ed472e3679c2df4bc2784598554ca930113eeecf)