### PR TITLE
fixed real directory for Errai Wildfly distribution

### DIFF
--- a/business-central-parent/pom.xml
+++ b/business-central-parent/pom.xml
@@ -38,7 +38,7 @@
 
   <properties>
     <!-- Add the absolute path for $JBOSS_HOME below to manage another instance -->
-    <errai.jboss.home>${project.build.directory}/wildfly-${version.org.jboss.errai.wildfly}</errai.jboss.home>
+    <errai.jboss.home>${project.build.directory}/wildfly-${version.org.wildfly}</errai.jboss.home>
     <gwt.compiler.localWorkers>1</gwt.compiler.localWorkers>
     <gwt.memory.settings>-Xmx6g -Xms1g -Xss1M</gwt.memory.settings>
     <login.bundle.name>org.kie.bc.client.resources.i18n.LoginConstants</login.bundle.name>


### PR DESCRIPTION
This is a change for having always directory for Errai Wildfly unpacked distribution to be on the same name as original wildfly distribution as Errai just repackaged it so naming directory to that version is not confusing