### PR TITLE
KOGITO-2664: [DMN Designer] Multiple DRDs support

### DIFF
--- a/business-central-parent/business-central-webapp/.gitignore
+++ b/business-central-parent/business-central-webapp/.gitignore
@@ -19,3 +19,13 @@
 
 # Repository wide ignore mac DS_Store files
 .DS_Store
+
+# Copied during build from kie-wb-common-dmn-webapp-kogito-marshaller
+/src/main/webapp/model/DC.js
+/src/main/webapp/model/DI.js
+/src/main/webapp/model/DMN12.js
+/src/main/webapp/model/DMNDI12.js
+/src/main/webapp/model/KIE.js
+/src/main/webapp/model/Jsonix-all.js
+/src/main/webapp/model/MainJs.js
+/src/main/webapp/model/FormatterJs.js

--- a/business-central-parent/business-central-webapp/pom.xml
+++ b/business-central-parent/business-central-webapp/pom.xml
@@ -2293,6 +2293,11 @@
       <artifactId>kie-wb-common-dmn-backend</artifactId>
       <scope>runtime</scope>
     </dependency>
+    <dependency>
+      <groupId>org.kie.workbench</groupId>
+      <artifactId>kie-wb-common-dmn-webapp-kogito-marshaller</artifactId>
+      <scope>provided</scope>
+    </dependency>
 
     <dependency>
       <groupId>org.kie.workbench.screens</groupId>
@@ -2648,6 +2653,7 @@
             <compileSourcesArtifact>org.kie.workbench:kie-wb-common-dmn-project-api</compileSourcesArtifact>
             <compileSourcesArtifact>org.kie.workbench:kie-wb-common-dmn-client</compileSourcesArtifact>
             <compileSourcesArtifact>org.kie.workbench:kie-wb-common-dmn-project-client</compileSourcesArtifact>
+            <compileSourcesArtifact>org.kie.workbench:kie-wb-common-dmn-webapp-kogito-marshaller</compileSourcesArtifact>
 
             <!-- Models for OptaPlanner Workbench Screens -->
             <compileSourcesArtifact>org.optaplanner:optaplanner-workbench-models-datamodel-api</compileSourcesArtifact>
@@ -2820,6 +2826,69 @@
               </artifactItems>
               <overWriteReleases>false</overWriteReleases>
               <overWriteSnapshots>true</overWriteSnapshots>
+            </configuration>
+          </execution>
+          <execution>
+            <id>Unpack DMNMarshaller JS from dependency</id>
+            <phase>process-sources</phase>
+            <goals>
+              <goal>unpack</goal>
+            </goals>
+            <configuration>
+              <artifactItems>
+                <artifactItem>
+                  <groupId>org.kie.workbench</groupId>
+                  <artifactId>kie-wb-common-dmn-webapp-kogito-marshaller</artifactId>
+                  <version>${version.org.kie}</version>
+                  <type>jar</type>
+                  <overWrite>true</overWrite>
+                  <outputDirectory>${project.build.directory}/DMNMarshaller</outputDirectory>
+                  <includes>**/*.js</includes>
+                </artifactItem>
+              </artifactItems>
+            </configuration>
+          </execution>
+          <execution>
+            <id>Unpack FormatterJS JS from dependency</id>
+            <phase>process-sources</phase>
+            <goals>
+              <goal>unpack</goal>
+            </goals>
+            <configuration>
+              <artifactItems>
+                <artifactItem>
+                  <groupId>org.kie.workbench</groupId>
+                  <artifactId>kie-wb-common-dmn-webapp-kogito-common</artifactId>
+                  <version>${version.org.kie}</version>
+                  <type>jar</type>
+                  <overWrite>true</overWrite>
+                  <outputDirectory>${project.build.directory}/DMNMarshaller</outputDirectory>
+                  <includes>**/*.js</includes>
+                </artifactItem>
+              </artifactItems>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-antrun-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>Copy DMNMarshaller JS to WAR</id>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>run</goal>
+            </goals>
+            <configuration>
+              <target>
+                <copy todir="${basedir}/src/main/webapp/model" flatten="true">
+                  <fileset dir="${project.build.directory}/DMNMarshaller">
+                    <include name="**/*.js"/>
+                  </fileset>
+                </copy>
+              </target>
             </configuration>
           </execution>
         </executions>

--- a/business-central-parent/business-central-webapp/pom.xml
+++ b/business-central-parent/business-central-webapp/pom.xml
@@ -2848,26 +2848,6 @@
               </artifactItems>
             </configuration>
           </execution>
-          <execution>
-            <id>Unpack FormatterJS JS from dependency</id>
-            <phase>process-sources</phase>
-            <goals>
-              <goal>unpack</goal>
-            </goals>
-            <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>org.kie.workbench</groupId>
-                  <artifactId>kie-wb-common-dmn-webapp-kogito-common</artifactId>
-                  <version>${version.org.kie}</version>
-                  <type>jar</type>
-                  <overWrite>true</overWrite>
-                  <outputDirectory>${project.build.directory}/DMNMarshaller</outputDirectory>
-                  <includes>**/*.js</includes>
-                </artifactItem>
-              </artifactItems>
-            </configuration>
-          </execution>
         </executions>
       </plugin>
 

--- a/business-central-parent/business-central-webapp/src/main/resources/org/kie/bc/KIEWebapp.gwt.xml
+++ b/business-central-parent/business-central-webapp/src/main/resources/org/kie/bc/KIEWebapp.gwt.xml
@@ -111,7 +111,9 @@
   <inherits name="org.drools.workbench.screens.pmmltext.DroolsWorkbenchPMMLTextEditorClient"/>
 
   <!-- DMN Editor -->
+  <inherits name="org.kie.workbench.common.dmn.project.DMNProjectAPI"/>
   <inherits name="org.kie.workbench.common.dmn.project.DMNProjectClient"/>
+  <inherits name="org.kie.workbench.common.dmn.webapp.kogito.marshaller.DMNMarshaller"/>
 
   <!-- Optaplanner Workbench Screens -->
   <inherits name="org.optaplanner.workbench.screens.domaineditor.OptaPlannerWorkbenchDomainEditorClient"/>

--- a/business-central-parent/business-central-webapp/src/main/webapp/kie-wb.jsp
+++ b/business-central-parent/business-central-webapp/src/main/webapp/kie-wb.jsp
@@ -35,6 +35,14 @@
     <link rel="shortcut icon" href="images/drools.gif" type="image/gif"/>
     <link rel="icon" href="images/drools.gif" type="image/gif"/>
 
+    <script type="text/javascript" src="model/Jsonix-all.js"></script>
+    <script type="text/javascript" src="model/DC.js"></script>
+    <script type="text/javascript" src="model/DI.js"></script>
+    <script type="text/javascript" src="model/DMNDI12.js"></script>
+    <script type="text/javascript" src="model/DMN12.js"></script>
+    <script type="text/javascript" src="model/KIE.js"></script>
+    <script type="text/javascript" src="model/MainJs.js"></script>
+    <script type="text/javascript" src="model/FormatterJs.js"></script>
 </head>
 <body>
   <iframe id="__gwt_historyFrame" style="width: 0; height: 0; border: 0"></iframe>

--- a/business-central-parent/business-central-webapp/src/main/webapp/kie-wb.jsp
+++ b/business-central-parent/business-central-webapp/src/main/webapp/kie-wb.jsp
@@ -42,7 +42,6 @@
     <script type="text/javascript" src="model/DMN12.js"></script>
     <script type="text/javascript" src="model/KIE.js"></script>
     <script type="text/javascript" src="model/MainJs.js"></script>
-    <script type="text/javascript" src="model/FormatterJs.js"></script>
 </head>
 <body>
   <iframe id="__gwt_historyFrame" style="width: 0; height: 0; border: 0"></iframe>


### PR DESCRIPTION
**JIRA**: [KOGITO-2664](https://issues.redhat.com/browse/KOGITO-2664): [DMN Designer] Multiple DRDs support

**Part of an ensemble**:
- https://github.com/kiegroup/kie-wb-common/pull/3379
- https://github.com/kiegroup/drools-wb/pull/1416
- https://github.com/kiegroup/kie-wb-distributions/pull/1054

## Artifacts
- **Business Central**: [WAR file v6](https://www.dropbox.com/s/6lovcz78ixv7a55/business-central-v6.war?dl=0)
- **VS Code**: [plugin v6](https://www.dropbox.com/s/ukfin8xsp5rl5sj/plugin-v6.vsix?dl=0)


## Demos

This PR covers the following JIRAs:

- [KOGITO-2665](https://issues.redhat.com/browse/KOGITO-2665): Marshaller - Adopt the first DMNDiagram as the DRG (author: @karreiro)
<img width="50%" src="https://user-images.githubusercontent.com/1079279/92027801-69abb180-ed39-11ea-83fa-ff09db191487.gif">
<img width="50%" src="https://user-images.githubusercontent.com/1079279/92027810-6ca6a200-ed39-11ea-91c8-1028635c722d.gif">

- [KOGITO-2965](https://issues.redhat.com/browse/KOGITO-2965): Graph - Palette changes (author: @danielzhe)
- [KOGITO-2666](https://issues.redhat.com/browse/KOGITO-2666): Graph - Create mechanism to switch context between graphs (author: @karreiro)

<img width="50%" src="https://user-images.githubusercontent.com/1079279/92027837-74fedd00-ed39-11ea-895c-02bd274b37f7.gif">

- [KOGITO-2669](https://issues.redhat.com/browse/KOGITO-2669): Decision Navigator - Split current navigator between the DRG and the multiple DRDs (author: @karreiro)
- [KOGITO-2670](https://issues.redhat.com/browse/KOGITO-2670): Decision Navigator - The DRD name must be editable into the decision navigator (author: @karreiro)

<img width="50%" src="https://user-images.githubusercontent.com/1079279/92027965-a5df1200-ed39-11ea-96a5-47709ed7d5ae.gif">

- [KOGITO-2991](https://issues.redhat.com/browse/KOGITO-2991): Graph - Keep DRG elements instances synchronised (author: @danielzhe)
- [KOGITO-2746](https://issues.redhat.com/browse/KOGITO-2746): Marshaller - Many nodes instances for a single DRG element (author: @karreiro)
- [KOGITO-2671](https://issues.redhat.com/browse/KOGITO-2671): Decision Components - The decision components widget must show DRGs from the current model (author: @danielzhe)

<img width="50%" src="https://user-images.githubusercontent.com/1079279/92028022-bdb69600-ed39-11ea-9cc1-eac328b9d185.gif">

- [KOGITO-2672](https://issues.redhat.com/browse/KOGITO-2672): Graph - Node remove command (trash icon) should not always delete the DRG element (author: @danielzhe)

<img width="50%" src="https://user-images.githubusercontent.com/1079279/92028034-c313e080-ed39-11ea-8ce1-eed374fd1c2c.gif">

- [KOGITO-2674](https://issues.redhat.com/browse/KOGITO-2674): Context menu component (@vpellegrino)
- [KOGITO-2675](https://issues.redhat.com/browse/KOGITO-2675): Context menu - Show the DRD clickable icon when node is selected (@vpellegrino)
- [KOGITO-3022](https://issues.redhat.com/browse/KOGITO-3022): Context menu - When multiple nodes are selected, showing context menu with right click (@vpellegrino)

<img width="50%" src="https://user-images.githubusercontent.com/1079279/92028054-cad38500-ed39-11ea-8224-3f0403c0d89a.gif">

- [KOGITO-2676](https://issues.redhat.com/browse/KOGITO-2676): Graph - The back link must show the DRD name (@vpellegrino)
- [KOGITO-2668](https://issues.redhat.com/browse/KOGITO-2668): Graph - When a DRD is focused, the name must appear above the canvas (@vpellegrino)

<img width="50%" src="https://user-images.githubusercontent.com/1079279/92028064-d030cf80-ed39-11ea-8829-9ebf343eda29.gif">

- [KOGITO-2964](https://issues.redhat.com/browse/KOGITO-2964): Marshaller - Use a single Marshaller on all DMN webapps (@karreiro)

<img width="50%" src="https://user-images.githubusercontent.com/1079279/92028789-facf5800-ed3a-11ea-9e64-3dc63ca1bdcc.png">

---

<pre>
To retest a PR or trigger a specific build please add a comment:

* Retest PR: <b>jenkins retest this</b>
* A full downstream build: <b>jenkins do fdb</b>
* A compile downstream build: <b>jenkins do cdb</b>
* A full production downstream build: <b>jenkins do product fdb</b>
* An upstream build: <b>jenkins do upstream</b>
</pre>
