### PR TITLE
BXMSPROD-1004 Switch OptaWeb releases from master to 7.x branch

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -24,7 +24,7 @@ jobs:
         id: build-chain
         uses: kiegroup/github-action-build-chain@v1.4
         with:
-          parent-dependencies: 'optaweb-vehicle-routing'
+          parent-dependencies: 'optaweb-vehicle-routing@master:7.x'
           build-command: 'mvn -e -nsu install -Dfull -Prun-code-coverage -Pwildfly -Dcontainer=wildfly -Dcontainer.profile=wildfly -Dintegration-tests=true -Dmaven.test.failure.ignore=true -Pbusiness-central -Dgwt.compiler.localWorkers=1 -Dwebdriver.firefox.bin=/opt/tools/firefox-60esr/firefox-bin'
           build-command-upstream: |
             mvn -e --builder smart -T1C install -DskipTests -Dgwt.compiler.skip=true -Dgwt.skipCompilation=true -Denforcer.skip=true -Dcheckstyle.skip=true -Dspotbugs.skip=true -Drevapi.skip=true


### PR DESCRIPTION
https://issues.redhat.com/browse/BXMSPROD-1004

https://github.com/kiegroup/optaweb-vehicle-routing/pull/368
https://github.com/kiegroup/optaweb-employee-rostering/pull/499
https://github.com/kiegroup/kie-docs/pull/2850
https://github.com/kiegroup/kie-wb-distributions/pull/1063