### PR TITLE
AF-2692 : Add a security permission to show project toolbar, Metrics tab and change request tab

### DIFF
--- a/business-central-parent/business-central-distribution-wars/business-central/src/main/productized/resources/security-policy.properties
+++ b/business-central-parent/business-central-distribution-wars/business-central/src/main/productized/resources/security-policy.properties
@@ -52,7 +52,9 @@ default.permission.globalpreferences.edit=false
 default.permission.profilepreferences.edit=false
 default.permission.datatransfer.access=false
 default.permission.guideddecisiontable.edit.columns=true
-
+default.permission.projecttoolbar.show=true
+default.permission.metricstab.show=true
+default.permission.changerequesttab.show=true
 # See https://issues.jboss.org/browse/GUVNOR-3524
 default.permission.editor.read.GuidedDecisionTreeEditorPresenter=false
 default.permission.editor.read.GuidedScoreCardEditor=false

--- a/business-central-parent/business-central-webapp/src/main/resources/security-policy.properties
+++ b/business-central-parent/business-central-webapp/src/main/resources/security-policy.properties
@@ -52,6 +52,9 @@ default.permission.globalpreferences.edit=false
 default.permission.profilepreferences.edit=false
 default.permission.datatransfer.access=false
 default.permission.guideddecisiontable.edit.columns=true
+default.permission.projecttoolbar.show=true
+default.permission.metricstab.show=true
+default.permission.changerequesttab.show=true
 
 # See https://issues.jboss.org/browse/GUVNOR-3524
 default.permission.perspective.read.ProvisioningManagementPerspective=true


### PR DESCRIPTION

**Thank you for submitting this pull request**

**AF-2692**: https://issues.redhat.com/browse/AF-2692
**referenced Pull Requests**: _(please edit the URLs of referenced pullrequests if they exist)_

https://github.com/kiegroup/appformer/pull/1081
https://github.com/kiegroup/kie-wb-common/pull/3510

- Added default permissions for these settings

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
