### PR TITLE
[7.48.x] JBPM-9542: Remove issue-keeper tool (#1080)

### DIFF
--- a/business-central-tests/business-central-tests-rest/src/test/java/org/kie/wb/test/rest/RestTestBase.java
+++ b/business-central-tests/business-central-tests-rest/src/test/java/org/kie/wb/test/rest/RestTestBase.java
@@ -41,8 +41,6 @@ import org.kie.wb.test.rest.client.RestWorkbenchClient;
 import org.kie.wb.test.rest.client.WorkbenchClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import qa.tools.ikeeper.client.JiraClient;
-import qa.tools.ikeeper.test.IKeeperJUnitConnector;
 
 public abstract class RestTestBase {
 
@@ -103,9 +101,6 @@ public abstract class RestTestBase {
             System.out.println();
         }
     };
-
-    @Rule
-    public IKeeperJUnitConnector issueKeeper = new IKeeperJUnitConnector(new JiraClient("https://issues.jboss.org"));
 
     protected static SpaceRequest createSpace(String name) {
         Space orgUnit = new Space();

--- a/business-central-tests/business-central-tests-rest/src/test/java/org/kie/wb/test/rest/functional/ProjectIntegrationTest.java
+++ b/business-central-tests/business-central-tests-rest/src/test/java/org/kie/wb/test/rest/functional/ProjectIntegrationTest.java
@@ -36,10 +36,10 @@ import org.guvnor.rest.client.ProjectResponse;
 import org.guvnor.rest.client.BranchResponse;
 import org.guvnor.rest.client.TestProjectRequest;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.kie.wb.test.rest.RestTestBase;
 import org.kie.wb.test.rest.client.NotSuccessException;
-import qa.tools.ikeeper.annotation.Jira;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -61,7 +61,7 @@ public class ProjectIntegrationTest extends RestTestBase {
     }
 
     @Test
-    @Jira("GUVNOR-2542")
+    @Ignore("GUVNOR-2542")
     public void testCreateProjectWithoutName() {
         CreateProjectRequest createProjectRequest = new CreateProjectRequest();
         createProjectRequest.setGroupId(GROUP_ID);
@@ -95,7 +95,7 @@ public class ProjectIntegrationTest extends RestTestBase {
         createProject("projectWithoutVersion", null, GROUP_ID, VERSION);
     }
 
-    @Jira("GUVNOR-2542")
+    @Ignore("GUVNOR-2542")
     @Test(expected = NotFoundException.class)
     public void testDeleteNotExistingProject() {
         try {

--- a/business-central-tests/business-central-tests-rest/src/test/java/org/kie/wb/test/rest/functional/RepositoryIntegrationTest.java
+++ b/business-central-tests/business-central-tests-rest/src/test/java/org/kie/wb/test/rest/functional/RepositoryIntegrationTest.java
@@ -25,10 +25,10 @@ import org.guvnor.rest.client.CloneProjectRequest;
 import org.guvnor.rest.client.JobStatus;
 import org.guvnor.rest.client.ProjectResponse;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.kie.wb.test.rest.RestTestBase;
 import org.kie.wb.test.rest.client.NotSuccessException;
-import qa.tools.ikeeper.annotation.Jira;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.kie.wb.test.rest.functional.Utils.getProjectNames;
@@ -43,7 +43,7 @@ public class RepositoryIntegrationTest extends RestTestBase {
     }
 
     @Test
-    @Jira("GUVNOR-2542")
+    @Ignore("GUVNOR-2542")
     public void testCloneRepositoryNotExistingUrl() {
         final CloneProjectRequest cloneProjectRequest = new CloneProjectRequest();
         cloneProjectRequest.setName("clonedRepoWithNotExistingUrl");

--- a/business-central-tests/business-central-tests-rest/src/test/java/org/kie/wb/test/rest/functional/SpaceIntegrationTest.java
+++ b/business-central-tests/business-central-tests-rest/src/test/java/org/kie/wb/test/rest/functional/SpaceIntegrationTest.java
@@ -27,10 +27,10 @@ import org.guvnor.rest.client.JobStatus;
 import org.guvnor.rest.client.ProjectResponse;
 import org.guvnor.rest.client.Space;
 import org.guvnor.rest.client.SpaceRequest;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.kie.wb.test.rest.RestTestBase;
 import org.kie.wb.test.rest.client.NotSuccessException;
-import qa.tools.ikeeper.annotation.Jira;
 
 public class SpaceIntegrationTest extends RestTestBase {
 
@@ -76,7 +76,7 @@ public class SpaceIntegrationTest extends RestTestBase {
     }
 
     @Test
-    @Jira("GUVNOR-2542")
+    @Ignore("GUVNOR-2542")
     public void testCreateWithDescription() {
         final Space space = new Space();
         space.setName("spaceWithDescription");

--- a/business-central-tests/pom.xml
+++ b/business-central-tests/pom.xml
@@ -96,11 +96,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>link.bek.tools</groupId>
-      <artifactId>issue-keeper-junit</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>


### PR DESCRIPTION
#1080 cherry-pick

Due to recent jira authentication changes we decided to stop using issue-keeper tool for preventing test method run. It was replaced by simple '@Ignore' junit annotations.

For more details see:
- https://issues.redhat.com/browse/JBPM-9542
- https://github.com/ibek/issue-keeper

**Thank you for submitting this pull request**

**JIRA**: _(please edit the JIRA link if it exists)_ 

[link](https://www.example.com)

**referenced Pull Requests**: _(please edit the URLs of referenced pullrequests if they exist)_

* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1564
* https://github.com/kiegroup/jbpm/pull/1831

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
