### PR TITLE
BXMSPROD-1214 Install takari error workaround

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -64,6 +64,8 @@ jobs:
           wget -P $M2_HOME/lib/ext https://repo1.maven.org/maven2/io/takari/aether/takari-local-repository/0.11.3/takari-local-repository-0.11.3.jar
           wget -P $M2_HOME/lib/ext https://repo1.maven.org/maven2/io/takari/takari-filemanager/0.8.3/takari-filemanager-0.8.3.jar
           wget -P $M2_HOME/lib/ext https://repo1.maven.org/maven2/io/takari/maven/takari-smart-builder/0.6.1/takari-smart-builder-0.6.1.jar
+        env:
+          M2_HOME: /usr/share/apache-maven-3.6.3
       # See https://docs.github.com/en/actions/guides/building-and-testing-java-with-maven#caching-dependencies
       - name: Cache Maven packages
         uses: actions/cache@v2


### PR DESCRIPTION
JIRA
https://issues.redhat.com/browse/BXMSPROD-1214

https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1595
https://github.com/kiegroup/kie-soup/pull/182
https://github.com/kiegroup/droolsjbpm-knowledge/pull/504
https://github.com/kiegroup/drools/pull/3406
https://github.com/kiegroup/optaplanner/pull/1177
https://github.com/kiegroup/lienzo-core/pull/141
https://github.com/kiegroup/lienzo-tests/pull/113
https://github.com/kiegroup/appformer/pull/1110
https://github.com/kiegroup/kie-uberfire-extensions/pull/111
https://github.com/kiegroup/jbpm/pull/1875
https://github.com/kiegroup/kie-jpmml-integration/pull/49
https://github.com/kiegroup/droolsjbpm-integration/pull/2405
https://github.com/kiegroup/kie-wb-playground/pull/103
https://github.com/kiegroup/kie-wb-common/pull/3579
https://github.com/kiegroup/drools-wb/pull/1465
https://github.com/kiegroup/jbpm-designer/pull/898
https://github.com/kiegroup/jbpm-work-items/pull/175
https://github.com/kiegroup/jbpm-wb/pull/1481
https://github.com/kiegroup/optaplanner-wb/pull/388
https://github.com/kiegroup/kie-wb-distributions/pull/1088
https://github.com/kiegroup/openshift-drools-hacep/pull/105
https://github.com/kiegroup/optaweb-employee-rostering/pull/574
https://github.com/kiegroup/optaweb-vehicle-routing/pull/433
https://github.com/kiegroup/optaweb-vehicle-routing/pull/435
https://github.com/kiegroup/optaweb-employee-rostering/pull/576