### PR TITLE
Update Gecko driver to the latest version (0.29.1)

### DIFF
--- a/business-central-tests/business-central-tests-gui/src/test/filtered-resources/arquillian.xml
+++ b/business-central-tests/business-central-tests-gui/src/test/filtered-resources/arquillian.xml
@@ -21,7 +21,7 @@ limitations under the License.
     <property name="waitModelInterval">15</property>
     <property name="firefox_binary">${webdriver.firefox.bin}</property>
     <property name="firefoxArguments">-headless</property>
-    <property name="firefoxDriverVersion">0.26.0</property>
-    <property name="firefoxDriverUrl">https://github.com/mozilla/geckodriver/releases/download/v0.26.0/geckodriver-v0.26.0-linux64.tar.gz</property>
+    <property name="firefoxDriverVersion">0.29.1/</property>
+    <property name="firefoxDriverUrl">https://github.com/mozilla/geckodriver/releases/download/v0.29.1/geckodriver-v0.29.1-linux64.tar.gz</property>
   </extension>
 </arquillian>


### PR DESCRIPTION
This version is compatible with Firefox 60 and later versions.
https://firefox-source-docs.mozilla.org/testing/geckodriver/Support.html

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
