### PR TITLE
RHPAM-3632 :Project cannot be cloned from Business Central Standalone

### DIFF
--- a/business-central-parent/business-central-webapp/pom.xml
+++ b/business-central-parent/business-central-webapp/pom.xml
@@ -2408,7 +2408,12 @@
         <filtering>true</filtering>
       </testResource>
     </testResources>
-
+    <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+        <filtering>true</filtering>
+      </resource>
+    </resources>
     <plugins>
       <plugin>
 	<artifactId>maven-war-plugin</artifactId>

--- a/business-central-parent/business-central-webapp/src/main/resources/modules/org/eclipse/jgit/main/module.xml
+++ b/business-central-parent/business-central-webapp/src/main/resources/modules/org/eclipse/jgit/main/module.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+~ Copyright 2021 Red Hat, Inc. and/or its affiliates.
+~
+~ Licensed under the Apache License, Version 2.0 (the "License");
+~ you may not use this file except in compliance with the License.
+~ You may obtain a copy of the License at
+~
+~       http://www.apache.org/licenses/LICENSE-2.0
+~
+~ Unless required by applicable law or agreed to in writing, software
+~ distributed under the License is distributed on an "AS IS" BASIS,
+~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+~ See the License for the specific language governing permissions and
+~ limitations under the License.
+-->
+<module name="org.eclipse.jgit" xmlns="urn:jboss:module:1.8">
+    <properties>
+        <property name="jboss.api" value="private"/>
+    </properties>
+    <!-- This file overrides the module.xml of the jgit inside EAP to use the version that is supported by business central (refer RHPAM-3632). -->
+    <resources>
+        <artifact name="org.eclipse.jgit:org.eclipse.jgit:${version.org.eclipse.jgit}"/>
+    </resources>
+
+    <dependencies>
+        <module name="org.slf4j"/>
+        <module name="org.slf4j.impl"/>
+        <module name="javax.api"/>
+        <module name="com.jcraft.jsch"/>
+        <module name="com.jcraft.jzlib"/>
+        <module name="com.googlecode.javaewah"/>
+        <module name="org.apache.httpcomponents.core"/>
+    </dependencies>
+</module>


### PR DESCRIPTION
**Thank you for submitting this pull request**

**RHPAM-3632**: _https://issues.redhat.com/browse/RHPAM-3632_ 

- It is needed since wildfly dependency coming from thorntail were adding older jgit version in project classpath that were causing conflict while running business central in standalone mode.
- Add changes that forces EAP to use the jgit dependency version that is supported by business central (5.8.0.202006091008-r).
- This will override the jgit module.xml inside EAP.

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
