### PR TITLE
[7.59.x] JBPM-9896 - Fix dependency for compilation Stunner on JDK 11 to JRE 8

### DIFF
--- a/business-central-parent/business-central-webapp/pom.xml
+++ b/business-central-parent/business-central-webapp/pom.xml
@@ -1114,6 +1114,10 @@
       <scope>runtime</scope>
       <exclusions>
         <exclusion>
+          <groupId>xml-apis</groupId>
+          <artifactId>xml-apis</artifactId>
+        </exclusion>
+        <exclusion>
           <groupId>org.jbpm</groupId>
           <artifactId>jbpm-workitems-core</artifactId>
         </exclusion>


### PR DESCRIPTION
Hi @mareknovotny, @mbiarnes, @romartin, @jomarko it is cherry-pick of https://github.com/kiegroup/kie-wb-distributions/pull/1127

**referenced Pull Requests**: 

* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1771
* https://github.com/kiegroup/kie-wb-distributions/pull/1129
* https://github.com/kiegroup/jbpm-wb/pull/1515
* https://github.com/kiegroup/kie-wb-common/pull/3685

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
