### PR TITLE
[7.59.x][BXMSPROD-1475] GHA maven version

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -18,6 +18,7 @@ jobs:
     strategy:
       matrix:
         java-version: [8, 11]
+        maven-version: ['3.8.1']
       fail-fast: false
     runs-on: ubuntu-18.04
     name: Maven Build
@@ -30,23 +31,24 @@ jobs:
           sudo rm -rf /opt/ghc
           docker rmi $(docker image ls -aq)
           df -h
-      - name: Set up JDK
-        uses: actions/setup-java@v1
+      - name: Setup Maven And Java Version
+        uses: s4u/setup-maven-action@v1.2.1
         with:
           java-version: ${{ matrix.java-version }}
+          maven-version: ${{ matrix.maven-version }}
       # See https://docs.github.com/en/actions/guides/building-and-testing-java-with-maven#caching-dependencies
       - name: Cache Maven packages
         uses: actions/cache@v2
         with:
           path: ~/.m2
-          key: ${{ runner.os }}-${{ matrix.java-version }}-m2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-${{ matrix.java-version }}-m2
+          key: ${{ runner.os }}-${{ matrix.java-version }}-maven${{ matrix.maven-version }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-${{ matrix.java-version }}-maven${{ matrix.maven-version }}-m2
       - name: Install firefox and set FIREFOX_FOLDER env variable
         run: |
           wget https://ftp.mozilla.org/pub/firefox/releases/60.9.0esr/linux-x86_64/en-US/firefox-60.9.0esr.tar.bz2
           tar -xf firefox-60.9.0esr.tar.bz2
           echo "FIREFOX_FOLDER=`pwd`/firefox" >> $GITHUB_ENV
-      - name: Build Chain ${{ matrix.java-version }}
+      - name: Build Chain ${{ matrix.java-version }}. Maven ${{ matrix.maven-version }}
         id: build-chain
         uses: kiegroup/github-action-build-chain@v2.6.3
         with:


### PR DESCRIPTION
https://issues.redhat.com/browse/BXMSPROD-1475

Related PRs:

* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1774
* https://github.com/kiegroup/kie-soup/pull/229
* https://github.com/kiegroup/droolsjbpm-knowledge/pull/551
* https://github.com/kiegroup/drools/pull/3837
* https://github.com/kiegroup/optaplanner/pull/1579
* https://github.com/kiegroup/lienzo-core/pull/153
* https://github.com/kiegroup/lienzo-tests/pull/127
* https://github.com/kiegroup/appformer/pull/1198
* https://github.com/kiegroup/kie-uberfire-extensions/pull/125
* https://github.com/kiegroup/jbpm/pull/2027
* https://github.com/kiegroup/kie-jpmml-integration/pull/66
* https://github.com/kiegroup/droolsjbpm-integration/pull/2608
* https://github.com/kiegroup/kie-wb-playground/pull/120
* https://github.com/kiegroup/kie-wb-common/pull/3687
* https://github.com/kiegroup/drools-wb/pull/1516
* https://github.com/kiegroup/jbpm-designer/pull/919
* https://github.com/kiegroup/jbpm-work-items/pull/217
* https://github.com/kiegroup/jbpm-wb/pull/1517
* https://github.com/kiegroup/optaplanner-wb/pull/406
* https://github.com/kiegroup/kie-wb-distributions/pull/1131
* https://github.com/kiegroup/openshift-drools-hacep/pull/119
* https://github.com/kiegroup/process-migration-service/pull/25
* https://github.com/kiegroup/optaweb-employee-rostering/pull/692
* https://github.com/kiegroup/optaweb-vehicle-routing/pull/562
* https://github.com/kiegroup/kie-docs/pull/3895
