### PR TITLE
[7.59.x] Extend Business central deployment timeout for tests to 4 minutes

### DIFF
--- a/business-central-tests/pom.xml
+++ b/business-central-tests/pom.xml
@@ -279,6 +279,7 @@
                     <!-- disable incremental build to make tests less IO intensive and more stable (https://issues.jboss.org/browse/AF-1310) -->
                     <build.enable-incremental>false</build.enable-incremental>
                   </systemProperties>
+                  <timeout>240000</timeout>
                 </container>
                 <configuration>
                   <properties>


### PR DESCRIPTION
Signed-off-by: Karel Suta <ksuta@redhat.com>

**Thank you for submitting this pull request**

**referenced Pull Requests**:

* https://github.com/kiegroup/kie-wb-distributions/pull/1136

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
