### PR TITLE
[7.59.x] [RHPAM-4163] parametrize the bootable jar GAV used by wildfly-jar-maven-plugin

### DIFF
--- a/business-central-parent/business-central-distribution-wars/business-central/pom.xml
+++ b/business-central-parent/business-central-distribution-wars/business-central/pom.xml
@@ -202,7 +202,7 @@
             <groupId>org.wildfly.plugins</groupId>
             <artifactId>wildfly-jar-maven-plugin</artifactId>
             <configuration>
-              <feature-pack-location>wildfly@maven(org.jboss.universe:community-universe)#${version.org.wildfly}</feature-pack-location>
+              <feature-pack-location>${wildfly.bootable.jar.gav}</feature-pack-location>
               <layers>
                 <layer>logging</layer>
                 <layer>undertow</layer>

--- a/business-central-parent/pom.xml
+++ b/business-central-parent/pom.xml
@@ -159,7 +159,7 @@
           <artifactId>wildfly-jar-maven-plugin</artifactId>
           <configuration>
             <outputFileName>${project.build.finalName}-standalone.jar</outputFileName>
-            <feature-pack-location>wildfly@maven(org.jboss.universe:community-universe)#${version.org.wildfly}</feature-pack-location>
+            <feature-pack-location>${wildfly.bootable.jar.gav}</feature-pack-location>
             <layers>
               <layer>logging</layer>
               <layer>undertow</layer>

--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,7 @@
     <errai.marshalling.very_short_names>false</errai.marshalling.very_short_names>
     <!-- The version greater than 1.0.0.GA is not compatible with GWT 2.8.x -->
     <version.javax.validation>1.0.0.GA</version.javax.validation>
+    <wildfly.bootable.jar.gav>org.wildfly:wildfly-galleon-pack:${version.org.wildfly}</wildfly.bootable.jar.gav>
   </properties>
 
   <repositories>


### PR DESCRIPTION
**JIRA**: https://issues.redhat.com/browse/RHPAM-4163

I'm submitting this PR first to 7.59.x branch (because https://github.com/kiegroup/kie-wb-distributions/pull/1144 is missing for now in main branch) and as soon it gets merged, I will submit it to main branch.

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
