### PR TITLE
[7.67.x] RHPAM-4455 org.w3c.dom.* ignored from ban-duplicated-classes

### DIFF
--- a/business-central-parent/business-central-webapp/pom.xml
+++ b/business-central-parent/business-central-webapp/pom.xml
@@ -1107,10 +1107,6 @@
       <scope>runtime</scope>
       <exclusions>
         <exclusion>
-          <groupId>xml-apis</groupId>
-          <artifactId>xml-apis</artifactId>
-        </exclusion>
-        <exclusion>
           <groupId>org.jbpm</groupId>
           <artifactId>jbpm-workitems-core</artifactId>
         </exclusion>
@@ -1215,13 +1211,12 @@
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-backend-server</artifactId>
       <scope>runtime</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>xml-apis</groupId>
-          <artifactId>xml-apis</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
+    <dependency>
+      <groupId>org.w3c</groupId>
+      <artifactId>dom</artifactId>
+    </dependency>
+
     <dependency>
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-client</artifactId>


### PR DESCRIPTION
Ticket: https://issues.redhat.com/browse/RHPAM-4455

- https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/2027
- https://github.com/kiegroup/droolsjbpm-integration/pull/2836
- https://github.com/kiegroup/kie-wb-common/pull/3760
- https://github.com/kiegroup/kie-wb-distributions/pull/1178

Backporting:

- https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/2023