### PR TITLE
[7.67.x-blue] RHPAM-4455 org.w3c.dom.* ignored from ban-duplicated-classes

### DIFF
--- a/business-central-parent/business-central-webapp/pom.xml
+++ b/business-central-parent/business-central-webapp/pom.xml
@@ -1049,10 +1049,6 @@
       <scope>runtime</scope>
       <exclusions>
         <exclusion>
-          <groupId>xml-apis</groupId>
-          <artifactId>xml-apis</artifactId>
-        </exclusion>
-        <exclusion>
           <groupId>org.jbpm</groupId>
           <artifactId>jbpm-workitems-core</artifactId>
         </exclusion>
@@ -1157,13 +1153,12 @@
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-backend-server</artifactId>
       <scope>runtime</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>xml-apis</groupId>
-          <artifactId>xml-apis</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
+    <dependency>
+      <groupId>org.w3c</groupId>
+      <artifactId>dom</artifactId>
+    </dependency>
+
     <dependency>
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-client</artifactId>


### PR DESCRIPTION
Ticket: https://issues.redhat.com/browse/RHPAM-4455

- https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/2028
- https://github.com/kiegroup/droolsjbpm-integration/pull/2837
- https://github.com/kiegroup/kie-wb-common/pull/3761
- https://github.com/kiegroup/kie-wb-distributions/pull/1179

Backporting:

- https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/2023