### PR TITLE
[7.67.x] Revert "RHPAM-4387 xml-apis:xml-apis excluded"

### DIFF
--- a/business-central-parent/business-central-webapp/pom.xml
+++ b/business-central-parent/business-central-webapp/pom.xml
@@ -1171,11 +1171,6 @@
       <scope>runtime</scope>
     </dependency>
     <dependency>
-      <groupId>org.w3c</groupId>
-      <artifactId>dom</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-client</artifactId>
       <scope>provided</scope>


### PR DESCRIPTION
jbpm-wb not needed

Related PRs:

* https://github.com/kiegroup/kie-wb-distributions/pull/1189
* https://github.com/kiegroup/drools-wb/pull/1554
* https://github.com/kiegroup/kie-wb-common/pull/3773