### PR TITLE
[7.67.x] update EAP XP to version 4.0.0.GA-redhat-00007

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
     <!-- The version greater than 1.0.0.GA is not compatible with GWT 2.8.x -->
     <version.javax.validation>1.0.0.GA</version.javax.validation>
     <wildfly.bootable.jar.gav>org.wildfly:wildfly-galleon-pack:${version.org.wildfly}</wildfly.bootable.jar.gav>
-    <wildfly.bootable.productized.jar.gav>org.jboss.eap:wildfly-galleon-pack:4.0.0.GA-redhat-00004</wildfly.bootable.productized.jar.gav>
+    <wildfly.bootable.productized.jar.gav>org.jboss.eap:wildfly-galleon-pack:4.0.0.GA-redhat-00007</wildfly.bootable.productized.jar.gav>
   </properties>
 
   <repositories>


### PR DESCRIPTION
Version 4.0.0.GA-redhat-00007 is the latest released version and it is EAP XP on top of EAP 7.4.6


**referenced Pull Requests**: 


<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
