### PR TITLE
[7.67.x] [BXMSPROD-1845] elasticsearch removed from appformer

### DIFF
--- a/business-central-parent/business-central-webapp/pom.xml
+++ b/business-central-parent/business-central-webapp/pom.xml
@@ -557,11 +557,6 @@
       <scope>runtime</scope>
     </dependency>
     <dependency>
-      <groupId>org.uberfire</groupId>
-      <artifactId>uberfire-metadata-backend-elasticsearch</artifactId>
-      <scope>runtime</scope>
-    </dependency>
-    <dependency>
       <groupId>org.kie.workbench.services</groupId>
       <artifactId>kie-wb-common-refactoring-client</artifactId>
       <scope>provided</scope>


### PR DESCRIPTION
https://issues.redhat.com/browse/BXMSPROD-1845

Related PRs:

* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/2101
* https://github.com/kiegroup/appformer/pull/1316
* https://github.com/kiegroup/kie-wb-common/pull/3783
* https://github.com/kiegroup/drools-wb/pull/1559
* https://github.com/kiegroup/jbpm-wb/pull/1573
* https://github.com/kiegroup/kie-wb-distributions/pull/1197
* https://github.com/kiegroup/optaplanner-wb/pull/414