### PR TITLE
[7.67.x-blue] Updating plexus utils version to 3.6.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -123,6 +123,12 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+      <!-- Override plexus-utils transitive dependency version -->
+      <dependency>
+        <groupId>org.codehaus.plexus</groupId>
+        <artifactId>plexus-utils</artifactId>
+        <version>3.6.1</version>
+      </dependency>
       <!-- dependencies for jbpm-server-distribution -->
       <dependency>
         <groupId>org.jbpm</groupId>


### PR DESCRIPTION
Updating plexus utils version to 3.6.1 resolves the [CVE-2025-67030]
Linked PRs :
https://github.com/kiegroup/drools-wb/pull/1578
https://github.com/kiegroup/jbpm-work-items/pull/333
https://github.com/kiegroup/kie-jpmml-integration/pull/96
https://github.com/kiegroup/kie-wb-common/pull/3848
https://github.com/kiegroup/process-migration-service/pull/145